### PR TITLE
Add ci and analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and type check
+        run: npm run build
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.3",
         "@astrojs/tailwind": "^5.1.0",
+        "@vercel/analytics": "^1.5.0",
         "astro": "^4.15.4",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.6.2"
@@ -1924,6 +1925,44 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@volar/kit": {
       "version": "2.4.23",
@@ -5388,22 +5427,6 @@
         "node": ">=18.12"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -7168,6 +7191,22 @@
       },
       "optionalDependencies": {
         "prettier": "2.8.7"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/yaml-language-server/node_modules/request-light": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.3",
     "@astrojs/tailwind": "^5.1.0",
+    "@vercel/analytics": "^1.5.0",
     "astro": "^4.15.4",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.6.2"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,8 @@
 ---
 import '../styles/global.css';
+import { inject } from '@vercel/analytics';
+
+inject();
 
 interface Props {
   title: string;


### PR DESCRIPTION
## Title:
  Add CI/CD workflow and Vercel Analytics

  ## What
  Adds automated testing and visitor analytics to the PhilaCon Valley
  website.

  ## Why
  **CI/CD Workflow:**
  - Ensures code quality before merging
  - Automatically validates builds on every PR
  - Prevents broken code from reaching production

  **Vercel Analytics:**
  - Tracks website visitors and page views
  - Provides insights into user behavior
  - Helps understand which content resonates with the community

  ## How
  **CI/CD Workflow (.github/workflows/ci.yml):**
  - Runs on every pull request and push to main
  - Installs dependencies and builds the site
  - Runs type checking via Astro check
  - Uploads build artifacts for review
  - Fails if build or type checking has errors

  **Vercel Analytics:**
  - Installed @vercel/analytics package (v1.5.0)
  - Integrated using inject() method in BaseLayout
  - Automatically tracks page views when deployed
  - Zero configuration required - works out of the box on Vercel

  ## Testing
  **CI Workflow:**
  - Workflow will run automatically when this PR is created
  - Check the Actions tab for build status
  - Verify build passes successfully

  **Vercel Analytics:**
  - Tested locally - build completes without errors
  - Analytics will activate automatically after deployment to Vercel
  - Data will appear in Vercel dashboard Analytics tab

  **Build verification:**
  - `npm run build` - Successful (8 pages, 0 errors)
  - All pages render correctly
  - No breaking changes to existing functionality

