### PR TITLE
Fix critical issues before inviting contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
-      
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build and type check
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.3",
         "@astrojs/tailwind": "^5.1.0",
+        "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^1.5.0",
         "astro": "^4.15.4",
         "tailwindcss": "^3.4.10",
@@ -1808,6 +1809,31 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.3",
     "@astrojs/tailwind": "^5.1.0",
+    "@tailwindcss/typography": "^0.5.19",
     "@vercel/analytics": "^1.5.0",
     "astro": "^4.15.4",
     "tailwindcss": "^3.4.10",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import { site, links } from '../config';
+
 const currentYear = new Date().getFullYear();
 
 type FooterLink = {
@@ -18,13 +20,13 @@ const footerLinks: Record<string, FooterLink[]> = {
     { name: 'Learning Resources', href: '/resources' },
     { name: 'Support Us', href: '/support' },
     { name: 'Contact', href: '/contact' },
-    { name: 'GitHub', href: 'https://github.com/philaconvalley', external: true },
+    { name: 'GitHub', href: links.github.org, external: true },
   ],
   Connect: [
-    { name: 'Luma', href: 'https://lu.ma/philaconvalley', external: true },
-    { name: 'Instagram', href: 'https://www.instagram.com/phlconvalley/', external: true },
-    { name: 'LinkedIn', href: 'https://www.linkedin.com/company/philaconvalley/', external: true },
-    { name: 'Twitter/X', href: 'https://x.com/PhlConValley', external: true },
+    { name: 'Luma', href: links.luma, external: true },
+    { name: 'Instagram', href: links.social.instagram, external: true },
+    { name: 'LinkedIn', href: links.social.linkedin, external: true },
+    { name: 'Twitter/X', href: links.social.twitter, external: true },
   ],
 };
 ---
@@ -43,8 +45,8 @@ const footerLinks: Record<string, FooterLink[]> = {
           Making Philly the tech hub it's meant to be: by us, for us.
         </p>
         <div class="mt-6">
-          <a href="mailto:waskar@philaconvalley.com" class="text-sm text-gray-400 hover:text-white transition-colors">
-            waskar@philaconvalley.com
+          <a href={`mailto:${site.email}`} class="text-sm text-gray-400 hover:text-white transition-colors">
+            {site.email}
           </a>
         </div>
       </div>
@@ -95,7 +97,7 @@ const footerLinks: Record<string, FooterLink[]> = {
             &copy; {currentYear} PhilaCon Valley. All rights reserved.
           </p>
           <a
-            href="https://github.com/philaconvalley/website"
+            href={links.github.website}
             target="_blank"
             rel="noopener noreferrer"
             class="text-sm text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -58,7 +58,7 @@ const currentPath = Astro.url.pathname;
           @click="mobileMenuOpen = !mobileMenuOpen"
           type="button"
           class="inline-flex items-center justify-center p-2 rounded-md text-gray-700 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
-          aria-expanded="false"
+          :aria-expanded="mobileMenuOpen.toString()"
         >
           <span class="sr-only">Open main menu</span>
           <!-- Hamburger icon -->
@@ -112,9 +112,3 @@ const currentPath = Astro.url.pathname;
     </div>
   </nav>
 </header>
-
-<style>
-  [x-cloak] {
-    display: none !important;
-  }
-</style>

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -9,7 +9,7 @@ interface Props {
 const {
   title,
   description = 'PhilaCon Valley - Philadelphia\'s tech community by us, for us. Centering Black, Brown, LGBTQIA+, and underrepresented folks in tech.',
-  image = '/images/og-image.jpg',
+  image = '/images/1200x675 banner.png',
   type = 'website',
 } = Astro.props;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,27 @@
+/**
+ * Central site configuration.
+ * All external integration URLs and identifiers live here so they can be
+ * updated in one place instead of scattered across dozens of components.
+ */
+
+export const site = {
+  name: 'PhilaCon Valley',
+  email: 'waskar@philaconvalley.com',
+  location: 'Philadelphia, PA',
+} as const;
+
+export const links = {
+  luma: 'https://lu.ma/philaconvalley',
+  lumaEmbed: 'https://luma.com/embed/calendar/cal-KkQjuykLZNrSChl/events',
+  openCollective: 'https://opencollective.com/philacon-valley',
+  formspree: 'https://formspree.io/f/xovklgrn',
+  github: {
+    org: 'https://github.com/philaconvalley',
+    website: 'https://github.com/philaconvalley/website',
+  },
+  social: {
+    instagram: 'https://www.instagram.com/phlconvalley/',
+    linkedin: 'https://www.linkedin.com/company/philaconvalley/',
+    twitter: 'https://x.com/PhlConValley',
+  },
+} as const;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import SEO from '../components/SEO.astro';
 import { inject } from '@vercel/analytics';
 
 inject();
@@ -8,15 +9,15 @@ interface Props {
   title: string;
   description?: string;
   image?: string;
+  type?: string;
 }
 
 const {
   title,
   description = 'PhilaCon Valley - Philadelphia\'s tech community by us, for us. Centering Black, Brown, LGBTQIA+, and underrepresented folks in tech.',
   image = '/images/1200x675 banner.png',
+  type = 'website',
 } = Astro.props;
-
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <!doctype html>
@@ -26,34 +27,28 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/images/pink circle sunset logo.png" />
     <link rel="apple-touch-icon" href="/images/pink circle sunset logo.png" />
-    <link rel="canonical" href={canonicalURL} />
 
-    <!-- Primary Meta Tags -->
-    <title>{title}</title>
-    <meta name="title" content={title} />
-    <meta name="description" content={description} />
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Poppins:wght@600;700;800;900&display=swap"
+    />
 
-    <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={canonicalURL} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content={new URL(image, Astro.site)} />
+    <SEO title={title} description={description} image={image} type={type} />
 
-    <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content={canonicalURL} />
-    <meta property="twitter:title" content={title} />
-    <meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content={new URL(image, Astro.site)} />
-    <meta property="twitter:site" content="@PhlConValley" />
-
-    <!-- Alpine.js from CDN -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <!-- Alpine.js -->
+    <script is:inline defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js"></script>
 
     <meta name="generator" content={Astro.generator} />
   </head>
   <body>
-    <slot />
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg">
+      Skip to main content
+    </a>
+    <main id="main-content">
+      <slot />
+    </main>
   </body>
 </html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import { site, links } from '../config';
 ---
 
 <BaseLayout
@@ -44,8 +45,8 @@ import Footer from '../components/Footer.astro';
               </div>
               <div>
                 <h3 class="font-bold mb-1">Email</h3>
-                <a href="mailto:waskar@philaconvalley.com" class="text-primary-600 hover:text-primary-700">
-                  waskar@philaconvalley.com
+                <a href={`mailto:${site.email}`} class="text-primary-600 hover:text-primary-700">
+                  {site.email}
                 </a>
               </div>
             </div>
@@ -71,7 +72,7 @@ import Footer from '../components/Footer.astro';
               </div>
               <div>
                 <h3 class="font-bold mb-1">Events</h3>
-                <a href="https://lu.ma/philaconvalley" target="_blank" rel="noopener noreferrer" class="text-primary-600 hover:text-primary-700">
+                <a href={links.luma} target="_blank" rel="noopener noreferrer" class="text-primary-600 hover:text-primary-700">
                   lu.ma/philaconvalley
                 </a>
               </div>
@@ -83,7 +84,7 @@ import Footer from '../components/Footer.astro';
             <h3 class="font-bold mb-4">Follow Us</h3>
             <div class="flex gap-4">
               <a
-                href="https://www.instagram.com/phlconvalley/"
+                href={links.social.instagram}
                 target="_blank"
                 rel="noopener noreferrer"
                 class="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center hover:bg-primary-100 transition-colors"
@@ -94,7 +95,7 @@ import Footer from '../components/Footer.astro';
                 </svg>
               </a>
               <a
-                href="https://www.linkedin.com/company/philaconvalley/"
+                href={links.social.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
                 class="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center hover:bg-primary-100 transition-colors"
@@ -105,7 +106,7 @@ import Footer from '../components/Footer.astro';
                 </svg>
               </a>
               <a
-                href="https://x.com/PhlConValley"
+                href={links.social.twitter}
                 target="_blank"
                 rel="noopener noreferrer"
                 class="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center hover:bg-primary-100 transition-colors"
@@ -116,7 +117,7 @@ import Footer from '../components/Footer.astro';
                 </svg>
               </a>
               <a
-                href="https://github.com/philaconvalley"
+                href={links.github.org}
                 target="_blank"
                 rel="noopener noreferrer"
                 class="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center hover:bg-primary-100 transition-colors"
@@ -134,7 +135,7 @@ import Footer from '../components/Footer.astro';
         <div>
           <h2 class="text-3xl font-bold mb-6">Send Us a Message</h2>
           <form
-            action="https://formspree.io/f/xovklgrn"
+            action={links.formspree}
             method="POST"
             class="space-y-6"
             x-data="{ submitted: false }"
@@ -267,9 +268,3 @@ import Footer from '../components/Footer.astro';
 
   <Footer />
 </BaseLayout>
-
-<style>
-  [x-cloak] {
-    display: none !important;
-  }
-</style>

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
+import { links } from '../config';
 ---
 
 <BaseLayout
@@ -69,7 +70,8 @@ import Button from '../components/Button.astro';
       <div class="max-w-4xl mx-auto">
         <div class="bg-white rounded-lg shadow-lg overflow-hidden flex justify-center p-4">
           <iframe
-            src="https://luma.com/embed/calendar/cal-KkQjuykLZNrSChl/events"
+            src={links.lumaEmbed}
+            title="PhilaCon Valley Event Calendar"
             width="100%"
             height="600"
             frameborder="0"
@@ -80,7 +82,7 @@ import Button from '../components/Button.astro';
           ></iframe>
         </div>
         <p class="text-center mt-4 text-gray-600">
-          Can't see the calendar? <a href="https://lu.ma/philaconvalley" target="_blank" rel="noopener noreferrer" class="text-primary-600 hover:text-primary-700 font-semibold">View on Luma</a>
+          Can't see the calendar? <a href={links.luma} target="_blank" rel="noopener noreferrer" class="text-primary-600 hover:text-primary-700 font-semibold">View on Luma</a>
         </p>
       </div>
     </div>
@@ -138,7 +140,7 @@ import Button from '../components/Button.astro';
         RSVP for our next event and become part of Philadelphia's thriving tech community.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <Button href="https://lu.ma/philaconvalley" external variant="secondary" size="lg">
+        <Button href={links.luma} external variant="secondary" size="lg">
           View Events on Luma
         </Button>
         <Button href="/join" variant="outline" size="lg" class="!text-white !border-white hover:!bg-white/10">

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
+import { links } from '../config';
 ---
 
 <BaseLayout
@@ -39,7 +40,7 @@ import Button from '../components/Button.astro';
           <p class="text-gray-600 mb-6">
             RSVP for our next Collab Lab or workshop. No experience required – just bring your curiosity and laptop.
           </p>
-          <Button href="https://lu.ma/philaconvalley" external variant="primary" class="w-full">
+          <Button href={links.luma} external variant="primary" class="w-full">
             View Events
           </Button>
         </div>
@@ -72,13 +73,13 @@ import Button from '../components/Button.astro';
             Stay updated on events, resources, and community news. Connect with us on your favorite platform.
           </p>
           <div class="space-y-2">
-            <Button href="https://www.instagram.com/phlconvalley/" external variant="outline" class="w-full">
+            <Button href={links.social.instagram} external variant="outline" class="w-full">
               Instagram
             </Button>
-            <Button href="https://www.linkedin.com/company/philaconvalley/" external variant="outline" class="w-full">
+            <Button href={links.social.linkedin} external variant="outline" class="w-full">
               LinkedIn
             </Button>
-            <Button href="https://x.com/PhlConValley" external variant="outline" class="w-full">
+            <Button href={links.social.twitter} external variant="outline" class="w-full">
               Twitter/X
             </Button>
           </div>
@@ -229,7 +230,7 @@ import Button from '../components/Button.astro';
         The best time to join was yesterday. The second best time is now.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <Button href="https://lu.ma/philaconvalley" external variant="secondary" size="lg">
+        <Button href={links.luma} external variant="secondary" size="lg">
           Attend Next Event
         </Button>
         <Button href="/contact" variant="outline" size="lg" class="!text-white !border-white hover:!bg-white/10">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -5,6 +5,7 @@ import Footer from '../../components/Footer.astro';
 import ProjectCard from '../../components/ProjectCard.astro';
 import Button from '../../components/Button.astro';
 import { getCollection } from 'astro:content';
+import { links } from '../../config';
 
 const projects = (await getCollection('projects')).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime()
@@ -158,7 +159,7 @@ const projects = (await getCollection('projects')).sort(
         <Button href="/contact" variant="secondary" size="lg">
           Submit Your Project
         </Button>
-        <Button href="https://github.com/philaconvalley" external variant="outline" size="lg" class="!text-white !border-white hover:!bg-white/10">
+        <Button href={links.github.org} external variant="outline" size="lg" class="!text-white !border-white hover:!bg-white/10">
           View on GitHub
         </Button>
       </div>
@@ -167,9 +168,3 @@ const projects = (await getCollection('projects')).sort(
 
   <Footer />
 </BaseLayout>
-
-<style>
-  [x-cloak] {
-    display: none !important;
-  }
-</style>

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -202,9 +202,3 @@ const levels = [...new Set(resources.map(r => r.data.level))];
 
   <Footer />
 </BaseLayout>
-
-<style>
-  [x-cloak] {
-    display: none !important;
-  }
-</style>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
+import { links } from '../config';
 ---
 
 <BaseLayout
@@ -117,7 +118,7 @@ import Button from '../components/Button.astro';
               Visit our Open Collective page to make a one-time or recurring contribution.
               All transactions are transparent and publicly visible.
             </p>
-            <Button href="https://opencollective.com/philacon-valley" external variant="primary" size="lg">
+            <Button href={links.openCollective} external variant="primary" size="lg">
               Donate on Open Collective
             </Button>
           </div>
@@ -194,7 +195,7 @@ import Button from '../components/Button.astro';
         Your support helps us build the Philadelphia tech community we want to see.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <Button href="https://opencollective.com/philacon-valley" external variant="secondary" size="lg">
+        <Button href={links.openCollective} external variant="secondary" size="lg">
           Donate Now
         </Button>
         <Button href="/contact" variant="outline" size="lg" class="!text-white !border-white hover:!bg-white/10">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,9 +3,6 @@
 @tailwind utilities;
 
 @layer base {
-  /* Import Google Fonts */
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Poppins:wght@600;700;800;900&display=swap');
-
   html {
     @apply scroll-smooth;
   }
@@ -43,6 +40,11 @@
   *:focus-visible {
     @apply outline-2 outline-offset-2 outline-primary-600 ring-2 ring-primary-500 ring-offset-2;
   }
+
+  /* Alpine.js cloak — hides elements until Alpine initialises */
+  [x-cloak] {
+    display: none !important;
+  }
 }
 
 @layer components {
@@ -65,22 +67,6 @@
     @apply bg-white rounded-lg shadow-md hover:shadow-xl transition-shadow duration-300;
   }
 
-  /* Button base */
-  .btn {
-    @apply inline-flex items-center justify-center px-6 py-3 font-semibold rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2;
-  }
-
-  .btn-primary {
-    @apply btn bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-500;
-  }
-
-  .btn-secondary {
-    @apply btn bg-accent-600 text-white hover:bg-accent-700 focus:ring-accent-500;
-  }
-
-  .btn-outline {
-    @apply btn border-2 border-primary-600 text-primary-600 hover:bg-primary-50 focus:ring-primary-500;
-  }
 }
 
 @layer utilities {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -45,5 +45,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 };


### PR DESCRIPTION
## Summary

Pre-contributor cleanup addressing broken functionality, accessibility failures, CI reliability, and maintainability issues found during a full CTO-level repo audit.

- **Fix broken content pages**: Install `@tailwindcss/typography` so `prose` classes actually style Markdown content on project/resource detail pages
- **Fix accessibility**: Dynamic `aria-expanded` on mobile menu, `title` on Luma iframe, skip-to-content link, `<main>` landmark
- **Fix CI determinism**: Update Node 18 (EOL) to Node 20, switch `npm install` to `npm ci` with committed lockfile
- **Single source of truth for SEO**: Wire orphaned `SEO.astro` component into `BaseLayout`, remove duplicated inline meta tags, add `type` prop for `og:type`
- **Centralize integration URLs**: New `src/config.ts` extracts Luma, Formspree, Open Collective, GitHub, social, and email URLs from 7 files into one config
- **Fix font loading**: Move Google Fonts from CSS `@import` inside `@layer` (spec issue) to `<link>` tags with `preconnect` hints
- **Pin Alpine.js**: Lock CDN to `3.15.11` instead of floating `@3.x.x`
- **Clean dead CSS**: Remove unused `.btn-*` classes from `global.css`, consolidate 4 duplicate `[x-cloak]` blocks into one global rule
- **Branch protection**: Enabled on `main` — requires `build-and-test` CI pass + 1 approving review

## Test plan

- [x] `npm run build` passes (0 errors, 8 pages built)
- [ ] Verify skip-nav link appears on Tab key press
- [ ] Verify mobile menu `aria-expanded` toggles in screen reader
- [ ] Verify Luma iframe announced with title by screen reader
- [ ] Verify fonts load without FOUT on fresh visit
- [ ] Verify all external links (Luma, Open Collective, socials) resolve correctly from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)