### PR TITLE
Ignore major version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       - 'dependencies'
     commit-message:
       prefix: 'deps'
+    ignore:
+      - dependency-name: 'astro'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'tailwindcss'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## Summary

Closed Dependabot PRs #16 (Astro 6), #17 (TypeScript 6), and #18 (Tailwind 4) — all are breaking major version upgrades that can't be merged without migration work.

Updated Dependabot config to ignore major version bumps for `astro`, `tailwindcss`, and `typescript`. Minor/patch updates (security fixes, bug fixes) will still be opened automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)