### PR TITLE
feat: Add security headers via vercel.json with CSP drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Build and type check
         run: npm run build
 
+      # The CSP allowlists build-generated inline scripts by hash, so a dependency
+      # that changes those bytes silently invalidates the policy. Fails loudly here
+      # rather than shipping an analytics script the browser will block.
+      - name: Check CSP script hashes match the build
+        run: npm run csp:hash
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -61,6 +67,11 @@ jobs:
 
       - name: Run e2e smoke suite
         run: npm run test:e2e
+
+      # Serves dist/ with the vercel.json headers applied — `astro preview` ignores
+      # them, so these assertions only mean anything under the dedicated config.
+      - name: Run security header suite
+        run: npm run test:csp
 
       - name: Upload Playwright report
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ test-results/
 playwright-report/
 blob-report/
 playwright/.cache/
+.vercel

--- a/e2e/csp.spec.ts
+++ b/e2e/csp.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Guards the security headers in `vercel.json` against the real production
+ * build. Runs under `playwright.csp.config.ts`, which serves `dist/` through
+ * `scripts/serve-with-headers.mjs` so the headers actually apply — `astro
+ * preview` ignores vercel.json, and `vercel dev` applies it to dev-server HTML
+ * that carries Vite HMR and a differently-hashed inline analytics script.
+ */
+
+interface Violation {
+  directive: string;
+  blockedURI: string;
+  disposition: 'enforce' | 'report';
+}
+
+declare global {
+  interface Window {
+    __cspViolations: Violation[];
+  }
+}
+
+/** Must run before `goto` — violations fire during initial parse. */
+async function recordViolations(page: Page) {
+  await page.addInitScript(() => {
+    window.__cspViolations = [];
+    document.addEventListener('securitypolicyviolation', (e) => {
+      window.__cspViolations.push({
+        directive: e.effectiveDirective,
+        blockedURI: e.blockedURI,
+        disposition: e.disposition as 'enforce' | 'report',
+      });
+    });
+  });
+}
+
+const read = (page: Page) => page.evaluate(() => window.__cspViolations);
+
+const PAGES = ['/', '/about', '/contact', '/resources', '/blog'];
+
+test.describe('Content-Security-Policy (enforcing)', () => {
+  for (const path of PAGES) {
+    test(`blocks nothing on ${path}`, async ({ page }) => {
+      await recordViolations(page);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      const enforced = (await read(page)).filter((v) => v.disposition === 'enforce');
+      expect(enforced, `enforced CSP violations on ${path}`).toEqual([]);
+    });
+  }
+
+  test('survives Alpine interaction (mobile menu open/close)', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await recordViolations(page);
+    await page.goto('/');
+
+    const toggle = page.getByRole('button', { name: 'Open main menu' });
+    await toggle.click();
+    await expect(page.locator('[data-testid="mobile-menu"]')).toBeVisible();
+    await toggle.click();
+
+    const enforced = (await read(page)).filter((v) => v.disposition === 'enforce');
+    expect(enforced, 'enforced CSP violations during Alpine interaction').toEqual([]);
+  });
+
+  test('serves every security header', async ({ page }) => {
+    const response = await page.goto('/');
+    const headers = response!.headers();
+
+    expect(headers['x-content-type-options']).toBe('nosniff');
+    expect(headers['x-frame-options']).toBe('DENY');
+    expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    expect(headers['content-security-policy']).toContain("frame-ancestors 'none'");
+    expect(headers['content-security-policy-report-only']).toBeTruthy();
+  });
+});
+
+test.describe('Content-Security-Policy-Report-Only (the strict experiment)', () => {
+  /**
+   * The report-only header drops 'unsafe-eval'. Alpine evaluates its directive
+   * expressions via `new Function()`, so this is expected to report — that
+   * report IS the data point for whether swapping to `@alpinejs/csp` is worth
+   * doing. If this ever stops reporting, the strict policy has become viable
+   * and the enforcing header should be tightened.
+   */
+  test('reports exactly the known Alpine eval gap, and nothing new', async ({ page }) => {
+    await recordViolations(page);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const reported = (await read(page)).filter((v) => v.disposition === 'report');
+
+    // Nothing beyond eval should be reported — fonts, styles, images, connect
+    // and form all already satisfy the strict policy. A new category here means
+    // a dependency started reaching somewhere the allowlist does not cover.
+    const unexpected = reported.filter((v) => !v.directive.startsWith('script-src'));
+    expect(unexpected, 'unexpected report-only violations beyond the Alpine eval gap').toEqual([]);
+
+    // Deliberate tripwire: this asserts the gap still EXISTS, so the test cannot
+    // pass vacuously. If it fails because no eval violations were reported, Alpine
+    // no longer needs eval — drop 'unsafe-eval' from the enforcing header and
+    // delete this assertion.
+    const evalViolations = reported.filter((v) => v.blockedURI === 'eval');
+    expect(
+      evalViolations.length,
+      "no eval violations reported — if Alpine no longer needs eval, remove 'unsafe-eval' from the enforcing CSP",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "format:check": "prettier --check .",
     "astro": "astro",
     "test:e2e": "playwright test",
+    "test:csp": "playwright test --config playwright.csp.config.ts",
+    "csp:hash": "node scripts/check-csp-hashes.mjs",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  // csp.spec.ts needs the vercel.json headers, which `astro preview` does not
+  // serve — it runs under playwright.csp.config.ts instead.
+  testIgnore: 'csp.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/playwright.csp.config.ts
+++ b/playwright.csp.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Separate from `playwright.config.ts` on purpose: the security headers in
+ * `vercel.json` only exist when the build is served through
+ * `scripts/serve-with-headers.mjs`. The main e2e config uses `astro preview`,
+ * which ignores vercel.json entirely — running these specs there would pass
+ * vacuously against a site with no CSP at all.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'csp.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:4322',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run build && node scripts/serve-with-headers.mjs 4322',
+    url: 'http://localhost:4322',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/scripts/check-csp-hashes.mjs
+++ b/scripts/check-csp-hashes.mjs
@@ -1,0 +1,107 @@
+/**
+ * Fails if the CSP script hashes in `vercel.json` no longer match the inline
+ * scripts in the production build.
+ *
+ * `@vercel/analytics/astro` emits an inline <script type="module"> whose exact
+ * bytes are baked into the build. The CSP allowlists it by sha256 hash, so any
+ * change to that dependency silently invalidates the hash — and a blocked
+ * analytics script fails quietly, with nothing user-visible to notice.
+ *
+ * This deliberately only DETECTS drift; it does not rewrite vercel.json. A bot
+ * silently repairing a security policy means the policy changes without a human
+ * ever reading the diff, which defeats the point of reviewing it. Loud failure
+ * is the feature.
+ *
+ * Requires `npm run build` to have run first. Usage: node scripts/check-csp-hashes.mjs
+ */
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const DIST = 'dist';
+const CSP_KEYS = ['Content-Security-Policy', 'Content-Security-Policy-Report-Only'];
+
+async function htmlFiles(dir, acc = []) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) await htmlFiles(path, acc);
+    else if (entry.name.endsWith('.html')) acc.push(path);
+  }
+  return acc;
+}
+
+/**
+ * Executable inline scripts only. `application/ld+json` is a data block — the
+ * browser never executes it, so CSP script-src does not apply.
+ */
+function inlineScripts(html) {
+  const found = [];
+  const re = /<script(?![^>]*\bsrc=)([^>]*)>([\s\S]*?)<\/script>/g;
+  let match;
+  while ((match = re.exec(html))) {
+    if (/type\s*=\s*["']application\/ld\+json["']/i.test(match[1])) continue;
+    found.push(match[2]);
+  }
+  return found;
+}
+
+const sha256 = (body) => `sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}`;
+
+try {
+  await stat(DIST);
+} catch {
+  console.error(`No ${DIST}/ directory. Run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+const found = new Map(); // hash -> example file
+for (const file of await htmlFiles(DIST)) {
+  const html = await readFile(file, 'utf8');
+  for (const body of inlineScripts(html)) {
+    const hash = sha256(body);
+    if (!found.has(hash)) found.set(hash, file);
+  }
+}
+
+const config = JSON.parse(await readFile('vercel.json', 'utf8'));
+const policies = (config.headers ?? [])
+  .flatMap((rule) => rule.headers)
+  .filter((header) => CSP_KEYS.includes(header.key));
+
+const problems = [];
+
+for (const [hash, example] of found) {
+  for (const policy of policies) {
+    if (!policy.value.includes(hash)) {
+      problems.push(`  missing from ${policy.key}: ${hash}\n    (inline script in ${example})`);
+    }
+  }
+}
+
+// Hashes still allowlisted but no longer present in the build are dead grants.
+for (const policy of policies) {
+  for (const hash of policy.value.match(/'sha256-[A-Za-z0-9+/=]+'/g) ?? []) {
+    const bare = hash.slice(1, -1);
+    if (!found.has(bare)) {
+      problems.push(
+        `  stale entry in ${policy.key}: ${bare}\n    (no inline script in the build matches this)`,
+      );
+    }
+  }
+}
+
+if (problems.length) {
+  console.error('CSP script hashes are out of sync with the build:\n');
+  console.error(problems.join('\n'));
+  console.error(
+    '\nA dependency that emits inline JavaScript most likely changed.\n' +
+      'Update the hashes in vercel.json by hand, then re-run this check.\n' +
+      'Do not simply delete the hash — that would allow the script only by\n' +
+      "loosening script-src with 'unsafe-inline'.\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `CSP hashes in sync: ${found.size} inline script(s) allowlisted across ${policies.length} policies.`,
+);

--- a/scripts/serve-with-headers.mjs
+++ b/scripts/serve-with-headers.mjs
@@ -1,0 +1,95 @@
+/**
+ * Serves the production build (`dist/`) with the response headers defined in
+ * `vercel.json`, so security headers can be tested locally against the real
+ * built output.
+ *
+ * `astro preview` serves dist/ but knows nothing about vercel.json, and
+ * `vercel dev` applies vercel.json but runs the *dev* server underneath —
+ * which injects Vite HMR, the Astro dev toolbar, and a differently-hashed
+ * inline analytics script. Neither reflects production. This does.
+ *
+ * Usage: node scripts/serve-with-headers.mjs [port]
+ */
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { join, extname, normalize } from 'node:path';
+
+const PORT = Number(process.argv[2] ?? 4322);
+const DIST = 'dist';
+
+const config = JSON.parse(await readFile('vercel.json', 'utf8'));
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+/** Headers from vercel.json whose `source` pattern matches this path. */
+function headersFor(pathname) {
+  const out = {};
+  for (const rule of config.headers ?? []) {
+    // vercel.json `source` is a path-to-regexp-ish pattern; the patterns used
+    // here are simple enough to treat as regex anchored at both ends.
+    let matches = false;
+    try {
+      matches = new RegExp(`^${rule.source}$`).test(pathname);
+    } catch {
+      matches = rule.source === pathname;
+    }
+    if (matches) for (const { key, value } of rule.headers) out[key] = value;
+  }
+  return out;
+}
+
+/** Resolve a URL path to a file inside dist/, following Astro's directory-index convention. */
+async function resolveFile(pathname) {
+  const safe = normalize(decodeURIComponent(pathname)).replace(/^(\.\.[/\\])+/, '');
+  const candidates = extname(safe)
+    ? [join(DIST, safe)]
+    : [join(DIST, safe, 'index.html'), join(DIST, `${safe}.html`)];
+
+  for (const c of candidates) {
+    try {
+      if ((await stat(c)).isFile()) return c;
+    } catch {
+      /* try next candidate */
+    }
+  }
+  return null;
+}
+
+const server = createServer(async (req, res) => {
+  const { pathname } = new URL(req.url, `http://localhost:${PORT}`);
+  const headers = headersFor(pathname);
+  const file = (await resolveFile(pathname)) ?? (await resolveFile('/404'));
+
+  if (!file) {
+    res.writeHead(404, { ...headers, 'Content-Type': MIME['.html'] });
+    res.end('<h1>404</h1>');
+    return;
+  }
+
+  const body = await readFile(file);
+  res.writeHead(file.endsWith('404.html') ? 404 : 200, {
+    ...headers,
+    'Content-Type': MIME[extname(file)] ?? 'application/octet-stream',
+    'Content-Length': body.length,
+  });
+  res.end(body);
+});
+
+server.listen(PORT, () => {
+  console.log(`Serving ${DIST}/ with vercel.json headers at http://localhost:${PORT}`);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' cdn.jsdelivr.net 'sha256-xBLRIEPyEi4wjnXKU0OdZPHuoVrkUo4zJHMQ/u4unzA='; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data:; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'"
+        },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; script-src 'self' cdn.jsdelivr.net 'sha256-xBLRIEPyEi4wjnXKU0OdZPHuoVrkUo4zJHMQ/u4unzA='; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data:; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options` and `Referrer-Policy` via `vercel.json`, plus the tooling to keep the CSP honest as the site changes.

## Why the allowlist looks the way it does

The CSP was derived from the **built output**, not from reading `src/`. That distinction matters: `@vercel/analytics/astro` emits a 2905-byte inline `<script type="module">` at build time that never appears in source. A source-only inventory would have shipped a policy that silently blocks analytics.

Two corrections to the original issue, worth knowing before reviewing the policy string:

- The issue asks to allowlist `va.vercel-scripts.com`. **Production doesn't load it** — Vercel Analytics serves same-origin from `/_vercel/insights/script.js`, and that hostname is only the dev/debug script. Allowlisting it would grant a permission for nothing, so it's omitted.
- The issue doesn't mention Alpine, which turns out to be the binding constraint. Alpine evaluates its directive expressions (`x-data="{ mobileMenuOpen: false }"`) through `new Function()` at runtime, which CSP treats as eval. A clean-looking `script-src 'self' cdn.jsdelivr.net` silently kills the mobile menu, contact form state, and resources filter.

## Enforcing plus report-only, not one or the other

Rather than guess how strict a policy the site can tolerate, this ships **two** headers. They're separate header names, so browsers evaluate them independently:

- `Content-Security-Policy` — includes `'unsafe-eval'` so Alpine works. Protects visitors today.
- `Content-Security-Policy-Report-Only` — identical but without `'unsafe-eval'`. Costs nothing and measures what a strict policy would break.

That experiment has already run locally, and the result is the useful part: **12 violations, all `script-src -> eval`, all from Alpine.** Nothing else — no font, style, image, connect, or form violations. So Alpine's eval dependency is the *only* thing between this site and a policy with no `'unsafe-eval'` at all, which makes a follow-up switch to `@alpinejs/csp` a well-scoped, evidence-backed piece of work rather than a guess.

## Hash instead of 'unsafe-inline', with a gate

The build-generated inline analytics script is allowlisted by `sha256-` hash rather than by loosening `script-src` with `'unsafe-inline'`. The tradeoff is brittleness: the hash covers exact bytes, so any change to `@vercel/analytics` invalidates it, and a blocked analytics script fails quietly with nothing user-visible to notice.

`scripts/check-csp-hashes.mjs` closes that gap by failing CI when the hashes drift from the build. It deliberately **only detects drift and never rewrites `vercel.json`** — a bot silently repairing a security policy would change it without a human ever reading the diff, which defeats the point of reviewing it.

## Why the tests need their own config

Neither obvious option tests this correctly. `astro preview` serves `dist/` but ignores `vercel.json` entirely, so assertions would pass vacuously against a site with no CSP. `vercel dev` applies `vercel.json` but runs the *dev* server underneath, serving HTML with Vite HMR, the Astro dev toolbar, and a differently-hashed analytics script — producing phantom violations that don't exist in production.

`scripts/serve-with-headers.mjs` serves the real `dist/` with the real headers, and `playwright.csp.config.ts` runs `e2e/csp.spec.ts` against it. The main e2e config now ignores that spec so it can't accidentally run header-less.

## Review focus

The `vercel.json` policy string itself is where a mistake would be most costly and least visible — CSP silently drops directives it doesn't recognize (a `style-arc` typo would fall back to `default-src` and block Google Fonts with no error anywhere).

Fixes #90