### PR TITLE
chore: Remove deprecated baseUrl and unused tsconfig path aliases

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,3 @@
 {
-  "extends": "astro/tsconfigs/strict",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "@components/*": ["src/components/*"],
-      "@layouts/*": ["src/layouts/*"],
-      "@content/*": ["src/content/*"]
-    }
-  }
+  "extends": "astro/tsconfigs/strict"
 }


### PR DESCRIPTION
Reduces `tsconfig.json` to just the Astro strict preset.

TypeScript 5.9 reports `baseUrl` as deprecated and slated for removal in 7.0, which surfaces as a red error on `tsconfig.json` in the editor. The option predates modern module resolution: it made every bare import ambiguous, since TypeScript had to decide whether `"utils"` meant a node module or `<baseUrl>/utils`. Under `moduleResolution: "bundler"` — which Astro's strict preset sets — it's redundant, because since TypeScript 5.0 `paths` resolves relative to `tsconfig.json` on its own.

The path aliases are removed alongside it rather than rewritten, because **nothing imports through them**. `src/` and `e2e/` use relative paths throughout; a search for `@/`, `@components/`, `@layouts/` and `@content/` imports returns zero results. Unused configuration is a liability on a repo taking outside contributions: it advertises a convention the codebase doesn't actually follow, so a contributor either trusts it and writes imports against an untested path, or spends time working out why nobody uses it. Aliases can be reintroduced deliberately if a real need appears.

Considered and rejected: adding `"ignoreDeprecations": "6.0"` to silence the error. That defers the identical work to a TypeScript 7 upgrade while leaving dead config in place.

Verified with `npm run build` (which runs `astro check`) and `npm run lint`; the editor diagnostic is clear.

No linked issue — this was noticed incidentally while working on #90 and kept separate so each change stays independently reviewable and revertible.