### PR TITLE
fix(a11y): Move Header/Footer into BaseLayout so landmarks are correct by construction

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,8 @@ src/
 │
 ├── layouts/
 │   └── BaseLayout.astro   # The HTML shell every page shares
-│                          # Includes: <head>, fonts, SEO, analytics, skip nav
+│                          # Includes: <head>, fonts, SEO, analytics, skip nav,
+│                          # Header, <main> wrapper, Footer
 │
 ├── pages/                 # Each file = one URL on the site
 │   ├── index.astro        # / (homepage)
@@ -85,13 +86,13 @@ Every page follows the same pattern:
 
 ```astro
 <BaseLayout title="Page Title">
-  <Header />
-  <!-- page content -->
-  <Footer />
+  <!-- page content only — no <Header />, <Footer />, or <main> -->
 </BaseLayout>
 ```
 
-`BaseLayout` provides the `<html>`, `<head>` (with SEO, fonts, analytics), and the `<main>` wrapper.
+`BaseLayout` provides the `<html>`, `<head>` (with SEO, fonts, analytics), the skip link, `<Header />`, the `<main>` wrapper around the slot, and `<Footer />`.
+
+Pages used to import and render `<Header />` / `<Footer />` themselves. They no longer do, and shouldn't — that put both components _inside_ `<main>`, which demotes `<header>` from the `banner` landmark and `<footer>` from `contentinfo`, and made the "Skip to main content" link land above the nav instead of past it. Owning the chrome in the layout makes the landmark order correct by construction on every page rather than by convention on each one. There is deliberately no opt-out prop: if a page ever genuinely needs bare chrome, add a separate layout rather than a flag that can silently strip landmarks from the other pages.
 
 ## CI/CD
 

--- a/e2e/landmarks.spec.ts
+++ b/e2e/landmarks.spec.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect } from '@playwright/test';
+
+/**
+ * BaseLayout owns <Header />, <main> and <Footer /> so that every page gets the
+ * same landmark structure by construction (issue #87). These tests are the part
+ * that keeps it true: pages used to render Header/Footer themselves, into the
+ * layout's <main> slot, which silently demoted <header> out of the `banner` role
+ * and <footer> out of `contentinfo`, and left "Skip to main content" landing
+ * above the nav instead of past it. Nothing failed — it just shipped that way on
+ * all 13 pages.
+ *
+ * Routes are enumerated from dist/ rather than hardcoded, so a page added later
+ * is covered without anyone remembering to add it here.
+ */
+function builtRoutes(): string[] {
+  const dist = path.resolve(process.cwd(), 'dist');
+  return fs
+    .readdirSync(dist, { recursive: true })
+    .map(String)
+    .filter((f) => f.endsWith('.html'))
+    .map((f) => '/' + f.replace(/(^|\/)index\.html$/, '').replace(/\.html$/, ''))
+    .sort();
+}
+
+test.describe('landmark structure', () => {
+  test('every built page exposes exactly one banner, main and contentinfo', async ({ page }) => {
+    const routes = builtRoutes();
+    // A silently empty route list would make this test pass while checking nothing.
+    expect(routes.length).toBeGreaterThan(5);
+
+    for (const route of routes) {
+      await page.goto(route);
+
+      // Roles, not tags, on purpose: a <header> nested inside <main> is still a
+      // <header> element but is no longer the banner landmark, so counting roles
+      // is what actually catches the regression.
+      await expect(page.getByRole('banner'), `banner on ${route}`).toHaveCount(1);
+      await expect(page.getByRole('main'), `main on ${route}`).toHaveCount(1);
+      await expect(page.getByRole('contentinfo'), `contentinfo on ${route}`).toHaveCount(1);
+
+      const main = page.getByRole('main');
+      await expect(main.locator('header'), `header nested in main on ${route}`).toHaveCount(0);
+      await expect(main.locator('footer'), `footer nested in main on ${route}`).toHaveCount(0);
+    }
+  });
+
+  test('the skip link skips past the nav rather than into it', async ({ page }) => {
+    await page.goto('/about');
+
+    // First tab stop on any page is the skip link itself.
+    await page.keyboard.press('Tab');
+    const skipLink = page.locator('a[href="#main-content"]');
+    await expect(skipLink).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    await expect(page).toHaveURL(/#main-content$/);
+
+    // The next tab stop must be inside <main>. When <main> wrapped the header,
+    // this landed on the first nav link instead and the skip link did nothing.
+    await page.keyboard.press('Tab');
+    const focusedIsInsideMain = await page.evaluate(() => {
+      const el = document.activeElement;
+      return !!el && el !== document.body && !!el.closest('main');
+    });
+    expect(focusedIsInsideMain).toBe(true);
+
+    const focusedIsInsideNav = await page.evaluate(
+      () => !!document.activeElement?.closest('header'),
+    );
+    expect(focusedIsInsideNav).toBe(false);
+  });
+});

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,8 @@
 ---
 import '../styles/global.css';
 import SEO from '../components/SEO.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
 import Analytics from '@vercel/analytics/astro';
 
 interface Props {
@@ -76,9 +78,20 @@ const {
     >
       Skip to main content
     </a>
+    {
+      /* Header and Footer live here, not in each page, so the landmark structure is
+        guaranteed by construction: the header element is the banner landmark and
+        the footer element is contentinfo only while they sit outside main, and the
+        skip link above only actually skips the nav if main starts after the nav.
+        Pages render page content into the slot and nothing else. */
+    }
+    <Header />
+
     <main id="main-content">
       <slot />
     </main>
+
+    <Footer />
 
     <!-- Expires time-bound claims against the visitor's clock, which a static build
          cannot do on its own. Served from public/ and loaded with `is:inline` so it

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,13 +1,9 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
 ---
 
 <BaseLayout title="Page Not Found - PhilaCon Valley">
-  <Header />
-
   <section class="section-padding">
     <div class="container-custom">
       <div class="max-w-2xl mx-auto text-center">
@@ -23,6 +19,4 @@ import Button from '../components/Button.astro';
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/_blog/[slug].astro
+++ b/src/pages/_blog/[slug].astro
@@ -1,8 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
 import Button from '../../components/Button.astro';
 
 export async function getStaticPaths() {
@@ -23,8 +21,6 @@ const { title, description, author, date, tags } = post.data;
 ---
 
 <BaseLayout title={`${title} - PhilaCon Valley Blog`} description={description}>
-  <Header />
-
   <section class="bg-brand-yellow text-brand-dark py-16">
     <div class="container-custom">
       <div class="max-w-3xl mx-auto">
@@ -100,6 +96,4 @@ const { title, description, author, date, tags } = post.data;
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/_blog/index.astro
+++ b/src/pages/_blog/index.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
 import Button from '../../components/Button.astro';
 import BlogPostCard from '../../components/BlogPostCard.astro';
 import { getCollection } from 'astro:content';
@@ -15,8 +13,6 @@ const posts = (await getCollection('blog')).sort(
   title="Blog - PhilaCon Valley"
   description="Community updates, event recaps, and member spotlights from PhilaCon Valley."
 >
-  <Header />
-
   <section class="bg-brand-yellow text-brand-dark py-20">
     <div class="container-custom">
       <div class="max-w-4xl mx-auto text-center">
@@ -118,6 +114,4 @@ const posts = (await getCollection('blog')).sort(
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
 import FounderNote from '../components/FounderNote.astro';
 ---
@@ -10,8 +8,6 @@ import FounderNote from '../components/FounderNote.astro';
   title="About PhilaCon Valley - Our Story & Mission"
   description="Learn about PhilaCon Valley's mission to make Philadelphia a tech hub by centering Black, Brown, LGBTQIA+, and underrepresented folks in tech."
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-brand-coral text-white py-20">
     <div class="container-custom">
@@ -313,6 +309,4 @@ import FounderNote from '../components/FounderNote.astro';
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import { site, links } from '../config';
 ---
 
@@ -9,8 +7,6 @@ import { site, links } from '../config';
   title="Contact PhilaCon Valley"
   description="Get in touch with PhilaCon Valley. We'd love to hear from you!"
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-brand-coral text-white py-20">
     <div class="container-custom">
@@ -332,6 +328,4 @@ import { site, links } from '../config';
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
 import PhotoGrid from '../components/PhotoGrid.astro';
 import { links } from '../config';
@@ -16,8 +14,6 @@ const photos = (await getCollection('gallery')).sort(
   title="Events - PhilaCon Valley"
   description="Join us for hands-on workshops, Collab Labs, and community events in Philadelphia."
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-brand-purple text-white py-20">
     <div class="container-custom">
@@ -219,6 +215,4 @@ const photos = (await getCollection('gallery')).sort(
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import EventBar from '../components/EventBar.astro';
 import BuilderNightTrack from '../components/BuilderNightTrack.astro';
 import { getCommunityData } from '../lib/community';
@@ -32,11 +30,9 @@ const stats = [
 ---
 
 <BaseLayout title="PhilaCon Valley — Come as you are. Leave with a flock.">
-  <Header />
-
   <!-- No <main> here: BaseLayout already wraps the page slot in
        <main id="main-content">, and nesting a second one is invalid HTML that
-       reports two main landmarks and strips the footer's contentinfo role. -->
+       reports two main landmarks. -->
   <div>
     <!-- Hero -->
     <section class="px-5 lg:px-[72px] pt-[76px] pb-[84px] lg:pt-[136px] lg:pb-[140px]">
@@ -147,8 +143,6 @@ const stats = [
       }
     </section>
   </div>
-
-  <Footer />
 
   <!-- Clears the fixed bottom bar so the footer's last line is never trapped under
        it. Carries the same expiry as the bar: once the bar removes itself, this

--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
 import { links } from '../config';
 ---
@@ -10,8 +8,6 @@ import { links } from '../config';
   title="Join PhilaCon Valley - Get Involved"
   description="Join Philadelphia's tech community by us, for us. Connect on Slack, attend events, and start building with us."
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-accent-400 text-white py-20">
     <div class="container-custom">
@@ -348,6 +344,4 @@ import { links } from '../config';
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,8 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
 import Button from '../../components/Button.astro';
 
 export async function getStaticPaths() {
@@ -20,8 +18,6 @@ const { title, description, techStack, githubUrl, liveUrl, contributors, status,
 ---
 
 <BaseLayout title={`${title} - PhilaCon Valley Projects`} description={description}>
-  <Header />
-
   <!-- Hero -->
   <section class="bg-gradient-to-br from-primary-600 to-accent-600 text-white py-16">
     <div class="container-custom">
@@ -159,6 +155,4 @@ const { title, description, techStack, githubUrl, liveUrl, contributors, status,
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
 import Button from '../../components/Button.astro';
 import { links } from '../../config';
 import { isPublicOrgProject } from '../../lib/community';
@@ -57,8 +55,6 @@ const displayNames: Record<string, string> = {
   title="Community Projects - PhilaCon Valley"
   description="Explore projects built by PhilaCon Valley community members. Open source, collaborative, and built in Philadelphia."
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-brand-purple text-white py-20">
     <div class="container-custom">
@@ -226,6 +222,4 @@ const displayNames: Record<string, string> = {
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/resources/[slug].astro
+++ b/src/pages/resources/[slug].astro
@@ -1,8 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
 import Button from '../../components/Button.astro';
 
 export async function getStaticPaths() {
@@ -21,8 +19,6 @@ const categoryColor = 'bg-white/20 text-white';
 ---
 
 <BaseLayout title={`${title} - PhilaCon Valley Resources`} description={description}>
-  <Header />
-
   <section class="bg-brand-coral text-white py-16">
     <div class="container-custom">
       <div class="max-w-4xl mx-auto">
@@ -149,6 +145,4 @@ const categoryColor = 'bg-white/20 text-white';
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
 import ResourceCard from '../../components/ResourceCard.astro';
 import Button from '../../components/Button.astro';
 import { getCollection } from 'astro:content';
@@ -19,8 +17,6 @@ const levels = [...new Set(resources.map((r) => r.data.level))];
   title="Learning Resources - PhilaCon Valley"
   description="Free tutorials, workshops, and career resources for learning web development and tech skills."
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-brand-coral text-white py-20">
     <div class="container-custom">
@@ -222,6 +218,4 @@ const levels = [...new Set(resources.map((r) => r.data.level))];
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -1,7 +1,5 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
 import Button from '../components/Button.astro';
 import { links } from '../config';
 ---
@@ -10,8 +8,6 @@ import { links } from '../config';
   title="Support PhilaCon Valley - Donate"
   description="Support PhilaCon Valley's mission to make Philadelphia a tech hub by us, for us. Your donation keeps events free and accessible."
 >
-  <Header />
-
   <!-- Hero Section -->
   <section class="bg-brand-purple text-white py-20">
     <div class="container-custom">
@@ -242,6 +238,4 @@ import { links } from '../config';
       </div>
     </div>
   </section>
-
-  <Footer />
 </BaseLayout>


### PR DESCRIPTION
Moves `<Header />` and `<Footer />` out of all 13 pages and into `BaseLayout.astro`, which now renders skip link → `Header` → `<main id="main-content">` (page slot only) → `Footer`.

Issue #87 filed this as a code-tidiness question — 13 files repeating the same two imports, documented in `docs/architecture.md` as an intentional pattern. Two things turned up while looking at it.

**No page ever opted out.** Diffing the list of pages using `BaseLayout` against the list importing `Header` gives an empty set. The "intentional pattern" was never once exercised as a choice.

**The duplication was hiding a live accessibility bug.** `BaseLayout` wraps its slot in `<main id="main-content">`, and pages rendered their chrome *into that slot* — so `<header>` and `<footer>` were nested inside `<main>` on every page. Verified against production (`philaconvalley.com/about`: `<main>` at byte 6676, `<header>` at 6702, `</main>` at 29607):

- `<header>` was never the `banner` landmark and `<footer>` was never `contentinfo`. Nested inside `main`, both demote to generic, so screen-reader landmark navigation had no banner or contentinfo to jump to.
- "Skip to main content" landed *above* the nav, so keyboard users still tabbed through every nav link — precisely the thing a skip link exists to prevent.

Nothing was failing or looked wrong, which is the point: 13 copies of a correct-looking pattern turned one wrong decision into 13 instances of it, with no single place to fix it.

**No opt-out prop**, though #87 suggested one. The payoff of this change is the invariant "every page has correct landmarks," and a `noChrome`-style flag trades that invariant for a hypothetical, reintroducing exactly the per-page divergence being removed. If a page ever genuinely needs bare chrome, that's a separate layout — a small change that cannot retroactively break the other pages. This reasoning is recorded in `docs/architecture.md` so the prop doesn't get re-added later as an obvious improvement.

### Reviewer notes

- `e2e/landmarks.spec.ts` is the part that keeps this true. It enumerates routes from `dist/` rather than a hardcoded list, so a page added later is covered without anyone remembering to update the test; asserts exactly one `banner` / `main` / `contentinfo` per page **by ARIA role rather than by tag** (a nested `<header>` is still a `<header>` element — only the role check catches the regression); and drives the skip link by keyboard to assert the next tab stop lands inside `<main>`.
- The test was verified non-vacuous by temporarily restoring the old nesting and confirming both cases fail (`banner` count 0, focus landing inside the nav).
- `docs/architecture.md` reverses guidance it previously gave, so it's worth reading as part of the review rather than skimming as a doc touch-up.
- The page diffs are mechanical and identical: two imports and two render lines removed. `src/pages/index.astro` additionally drops one now-stale clause from a comment about landmark nesting.
- 12 pages build rather than 13 — `src/pages/_blog/*` is underscore-prefixed and excluded from the build by Astro, but was updated for consistency.

Verified: `lint` clean, `format:check` clean, `astro check` 0 errors / 0 warnings / 0 hints across 50 files, `test:e2e` 26 passed / 4 skipped, `test:csp` 8 passed, and a sweep of all 12 built pages confirming one landmark of each type in the correct order.

Closes #87