### PR TITLE
build(deps): Self-host Alpine.js instead of loading it from a CDN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/sitemap": "^3.7.3",
         "@tailwindcss/typography": "^0.5.20",
         "@vercel/analytics": "^2.0.1",
+        "alpinejs": "^3.15.12",
         "astro": "^7.1.1",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.6.2"
@@ -2721,6 +2722,21 @@
       "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
       "license": "MIT"
     },
+    "node_modules/@vue/reactivity": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.1.5"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2781,6 +2797,15 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.0.0-beta.0"
+      }
+    },
+    "node_modules/alpinejs": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
+      "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.1.1"
       }
     },
     "node_modules/am-i-vibing": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@astrojs/sitemap": "^3.7.3",
     "@tailwindcss/typography": "^0.5.20",
     "@vercel/analytics": "^2.0.1",
+    "alpinejs": "^3.15.12",
     "astro": "^7.1.1",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.6.2"

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,15 @@
 /// <reference path="../.astro/types.d.ts" />
+
+// Alpine ships no type declarations of its own, and the DefinitelyTyped package
+// trails the runtime by two minor versions — adding it would mean taking on a
+// dependency that is known to describe a different version than the one we run.
+// Only `start()` is called, and `window.Alpine` exists solely so the Alpine
+// devtools extension can find it, so the surface is declared here instead.
+declare module 'alpinejs' {
+  const Alpine: { start(): void };
+  export default Alpine;
+}
+
+interface Window {
+  Alpine: { start(): void };
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,9 +40,22 @@ const {
 
     <SEO title={title} description={description} image={image} type={type} />
 
-    <!-- Alpine.js -->
-    <script is:inline defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js"
-    ></script>
+    <!-- Alpine.js — bundled from node_modules rather than loaded from a CDN.
+         Alpine is the only JavaScript that reaches a visitor's browser, and as a
+         CDN tag it was the one dependency with no integrity guarantee (CSP checks
+         the origin, not the bytes) and no manifest entry, so Dependabot could not
+         see it either. Importing it here serves it from our own origin under
+         `script-src 'self'`, puts version bumps under Dependabot, and removes a
+         third-party failure domain: if the origin serving this is down, the page
+         it belongs to is already down. Note this does NOT remove the need for
+         'unsafe-eval' — Alpine evaluates x-* directives through `new Function`
+         wherever it is hosted. See e2e/csp.spec.ts. -->
+    <script>
+      import Alpine from 'alpinejs';
+
+      window.Alpine = Alpine;
+      Alpine.start();
+    </script>
 
     <meta name="generator" content={Astro.generator} />
 

--- a/vercel.json
+++ b/vercel.json
@@ -14,11 +14,11 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' cdn.jsdelivr.net 'sha256-o38oXzO4c2iT5Ighpvg1bDI3xAdM0Dn5yw4sye/KDRk='; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data:; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-eval' 'sha256-o38oXzO4c2iT5Ighpvg1bDI3xAdM0Dn5yw4sye/KDRk='; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data:; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'"
         },
         {
           "key": "Content-Security-Policy-Report-Only",
-          "value": "default-src 'self'; script-src 'self' cdn.jsdelivr.net 'sha256-o38oXzO4c2iT5Ighpvg1bDI3xAdM0Dn5yw4sye/KDRk='; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data:; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-o38oXzO4c2iT5Ighpvg1bDI3xAdM0Dn5yw4sye/KDRk='; font-src 'self' fonts.gstatic.com; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data:; connect-src 'self' formspree.io; form-action 'self' formspree.io; frame-ancestors 'none'"
         }
       ]
     }


### PR DESCRIPTION
Installs Alpine.js from npm and serves it from our own origin, replacing the jsDelivr CDN tag, and removes `cdn.jsdelivr.net` from both CSP policies.

Alpine is the only JavaScript that reaches a visitor's browser, and it was the one dependency with no integrity guarantee. The tag was version-pinned but carried no `integrity` attribute, and the CSP allowlists the jsDelivr origin in `script-src` — CSP checks the origin, not the bytes. Different bytes served at that pinned URL would have executed on every page, for every visitor, with CSP raising no objection. Issue #105 argues carefully that the build-toolchain "high" severities are not visitor-facing, and it is right; the unstated corollary is that the single genuinely visitor-facing dependency was the one with no integrity check at all.

**The alternative considered was the one #89 proposes: add an SRI hash to the CDN tag.** That would have worked. SRI is a content hash, the browser refuses to execute if a single byte differs, and the failure mode is loud and immediate — the right direction to fail. It was a correct diagnosis of the problem. Installing the package was chosen because it closes three gaps where SRI closes one:

- *Integrity* — the bytes ship in the build and are verified once at install time against the lockfile's `sha512-nJvPAQ…`, in CI, rather than on every visitor's request.
- *Availability* — SRI does nothing here. If jsDelivr is down, a pinned-and-hashed script is exactly as absent as an unpinned one, and the added strictness makes it fail harder. Serving Alpine from the same origin as the HTML removes a third-party failure domain entirely: it can no longer be independently unreachable.
- *Visibility* — `alpinejs` appeared in no `package.json`, so Dependabot had never been able to see it. The one script running in a visitor's browser was the one nobody was watching. This is the same structural bug as the `sharp` and `picomatch` alerts fixed in #110: no manifest entry, no updater, no PR, ever.

It also drops SRI's maintenance cost, where the hash must be re-derived on every version bump. Version bumps are now Dependabot's job.

Two limits worth stating rather than letting a reviewer assume otherwise. `'unsafe-eval'` stays in the enforcing policy — Alpine evaluates `x-*` directives through `new Function` wherever it is hosted, and the report-only eval-gap test in `e2e/csp.spec.ts` passes unchanged, which is the evidence that nothing about that moved. And this relocates the supply chain rather than eliminating it: trust moves from jsDelivr-at-request-time to npm-plus-lockfile-at-install-time. That is better — one trust event, verified in CI, failing the build instead of a visitor's browser — but it is not "no supply chain."

Alpine ships no type declarations, and `@types/alpinejs` (3.13.11) trails the runtime (3.15.12) by two minor versions, so the small surface actually used is declared in `src/env.d.ts` rather than taking on a dependency known to describe a different version than the one we run.

**Please open the Vercel deploy preview and toggle the mobile menu at phone width before approving.** Everything automated passes on this branch — build, `csp:hash`, both Playwright suites including the Alpine mobile-menu interaction — but none of it exercises the deployed artifact. A bundling change that broke the menu on a real viewport is exactly the failure this repo has no test for.

One note for whoever merges: this and #110 both touch `package-lock.json` off the same base, so the second to merge will need its lockfile regenerated. That is the expected cost of splitting the work into two reviewable PRs.

Fixes #89