### PR TITLE
build(deps): Patch nanoid and brace-expansion DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3123,9 +3123,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5352,9 +5352,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
# Description

Two high-severity DoS advisories were open against transitive build-toolchain dependencies. Both existing semver ranges already permitted the patched releases, so this is a lockfile refresh — no manifest change, no dependency majors moved.

| Package | Was → Now | Pulled in by | Advisory |
| --- | --- | --- | --- |
| `nanoid` | 3.3.16 → 3.3.18 | autoprefixer → postcss | Dependabot alert #48 |
| `brace-expansion` | 5.0.8 → 5.0.9 | eslint → minimatch | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) |

Neither package ships to visitors; both are dev-time only, so runtime output is unchanged.

Worth flagging for future triage: **`brace-expansion` was never raised as a Dependabot alert.** Only #48 was open. It surfaced in `npm audit` during the same run, which means the alert feed alone is not a complete picture of known advisories.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Bump `nanoid` 3.3.16 → 3.3.18 in `package-lock.json`
- Bump `brace-expansion` 5.0.8 → 5.0.9 in `package-lock.json`

## How Has This Been Tested?

- [x] Built successfully with `npm run build` — 12 pages, no new warnings
- [x] `npm run lint` passes clean
- [x] `npm audit` reports 0 vulnerabilities (was 1 high)

Not applicable: no visual or responsive changes, so mobile and accessibility checks were not run.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes locally