### PR TITLE
docs: Add PRODUCT.md and DESIGN.md as the design decision layer

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,80 @@
+# DESIGN.md — PhilaCon Valley website
+
+The **decision layer** for design work on this site: the visual thesis, the motion contract, and the rules that govern change.
+
+> **This is not the token reference.** `docs/design-system.md` is, and it is contributor-facing and already good. It owns colors, fonts, button variants, card styles, page hero assignments, and OG image specs. **Do not duplicate any of that here.** If a token value appears in both files, one of them is wrong — and it will be this one.
+>
+> Split of responsibility:
+>
+> - `docs/design-system.md` — _what the values are_, for someone making a change.
+> - `DESIGN.md` — _why they are what they are, and what must stay true_, for someone deciding a change.
+
+## Visual thesis
+
+**Retro-warm and hand-made, not clean-modern.** The site reads as friendly and slightly analog, and it earns that from four decisions working together — none of which survive alone:
+
+1. **Rounded display type.** Baloo 2 at heavy weights with tight negative tracking (`-0.03em` mobile, `-0.035em` desktop) on a 44px→96px hero. The roundness is the personality; the tightness stops it reading as childish.
+2. **Hard offset shadows, not blurred ones.** `4px 4px 0`, `6px 6px 0`, `8px 8px 0` at low-alpha near-black. Zero blur radius. This is the single most identity-bearing token in the system — a blurred shadow anywhere in the UI breaks the world more than a wrong color would.
+3. **Generous corner radius.** `20px` (`rounded-retro`) plus pill buttons.
+4. **Warm ground, cool never.** Cream body (`brand-cream`), amber/coral/pink/purple accents. There is no neutral gray in the palette and no cool tone anywhere. Introducing slate/zinc/blue-gray is the fastest way to make this site look like every other site.
+
+**Anti-references:** clean SaaS minimalism, glassmorphism, dark-mode-first dashboards, thin light-weight type, blurred drop shadows, gray neutrals.
+
+## Color rhythm
+
+Beyond the token table in `docs/design-system.md`, one systemic rule: **each page owns a hero color, and sections alternate cream → tinted cream → saturated** to create vertical rhythm. The hero color is a page's identity; changing one is a product decision, not a styling tweak.
+
+Contrast contract: white text on coral/purple/pink heroes, dark text on the yellow homepage hero. Any new hero color must be checked against both.
+
+## Type scale
+
+Defined in `src/styles/global.css` `@layer base`, fluid across three breakpoints:
+
+| Level | Mobile → Desktop                     |
+| ----- | ------------------------------------ |
+| h1    | `text-4xl` → `text-5xl` → `text-6xl` |
+| h2    | `text-3xl` → `text-4xl` → `text-5xl` |
+| h3    | `text-2xl` → `text-3xl` → `text-4xl` |
+| h4    | `text-xl` → `text-2xl`               |
+
+The homepage hero opts out with explicit pixel sizes because it is a display element, not a heading in the scale. That exception is deliberate and should stay rare — a second opt-out is a signal the scale is wrong.
+
+## Motion contract
+
+The strongest existing part of this system and the least documented outside code comments. Two families, and the distinction is an accessibility boundary, not a naming convention:
+
+| Family         | Behavior              | Purpose                                                                                      |
+| -------------- | --------------------- | -------------------------------------------------------------------------------------------- |
+| `.pcv-enter-*` | Runs **once** on load | Entrances — word, rise, stat, bar                                                            |
+| `.pcv-loop-*`  | Runs **forever**      | Narrates the Builder Night story: a dot arrives alone, two more join, you leave with a thing |
+
+**Rules:**
+
+1. **Looping motion is reserved for the Builder Night narrative on the homepage.** It is the page's only infinite motion. Do not add a second looping element anywhere without retiring this one — two competing loops destroy the narrative reading.
+2. **Every looping element must be legible in its final state**, because `prefers-reduced-motion` freezes it exactly there.
+3. **The reduced-motion block is deliberately unlayered** (outside `@layer`) so it wins against Tailwind's cascade order regardless of layer sorting. Do not move it into a layer.
+4. **`.pcv-loop-track` needs an explicit `width: 100%` under reduced motion.** It draws itself by animating width from 0; freezing it without restoring width leaves a zero-width line and the timeline dots sit on nothing. This is the one element that is unsafe to freeze naively.
+5. **Standard easing is `cubic-bezier(0.22, 1, 0.36, 1)`** for entrances and joins — a decelerating ease-out. Durations cluster at 0.8–1.0s for entrances and 8s for the loop cycle.
+6. **New motion goes through the `animate` skill**, per the design-team charter. `impeccable animate` is not used on this repo.
+
+## Known tensions
+
+Real conflicts between the current build and the tooling now installed. Each needs a decision before enforcement is switched on.
+
+1. **`.gradient-text` will trip the detector.** `src/styles/global.css` defines a gradient-text utility (`bg-clip-text text-transparent`, accent-400 → accent-600). Impeccable's detector lists **gradient text** as an immediate-tier mechanical violation. When `$impeccable hooks on` is run this will fire on every edit to files using it.
+   **Verified: it is defined and never used.** `grep -rn "gradient-text" src/ docs/` returns exactly one hit — the definition at `src/styles/global.css:61`. No template references it.
+   _Recommendation:_ delete the utility. It is dead code that will generate a recurring detector finding and an exception entry for a style the site does not use. Deleting is strictly cheaper than documenting an exception.
+2. **Google Fonts are loaded remotely** while Alpine.js was deliberately self-hosted for CSP and supply-chain reasons. That inconsistency is defensible but currently unstated.
+3. **`docs/design-system.md` says all pages use the default OG banner.** If per-page OG images are ever added, that doc and this one both need updating — it is the most likely drift point in the design docs.
+
+## How to change this system
+
+| Change              | Route                                                        |
+| ------------------- | ------------------------------------------------------------ |
+| A token value       | `tailwind.config.mjs`, then update `docs/design-system.md`   |
+| The type scale      | `src/styles/global.css` `@layer base`, then update this file |
+| Motion              | `animate` skill; obey the two-family rule above              |
+| A page's hero color | Product decision — update `docs/design-system.md` hero table |
+| The visual thesis   | Not a styling change. Re-run `/design-team doc`.             |
+
+Enforcement: `$impeccable hooks on` wires mechanical checks; `$impeccable doctor` reports drift between these docs and the code. Confirmed-intentional findings become exceptions via `hook-admin.mjs`, never by hand.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,69 @@
+# PRODUCT.md — PhilaCon Valley website
+
+Durable product context for design work. Facts here are derived from the codebase and repo docs, not invented. Numbers that change are named with their source rather than copied.
+
+## What this is
+
+The official website for **PhilaCon Valley** — a community-driven Philadelphia tech org centering Black, Brown, LGBTQIA+, and underrepresented folks in tech. The site is also an **open-source contributor project**: it is deliberately built to be a first-ever pull request for people in the community.
+
+That dual purpose is the single most important design constraint on this repo, and it is easy to forget. Every choice is judged twice — once as "does this serve a visitor?" and once as "can a first-time contributor understand and safely change this?"
+
+Live: `philaconvalley.com` · Repo: `philaconvalley/website` (public, MIT)
+
+## Who it serves
+
+| Audience                         | Arrives wanting                    | Leaves having                                    |
+| -------------------------------- | ---------------------------------- | ------------------------------------------------ |
+| **Prospective community member** | to know if this is for them        | RSVP'd to an event, or joined Slack              |
+| **Existing member**              | the next Builder Night, a resource | the date, the link, the thing                    |
+| **First-time OSS contributor**   | a safe place to make a PR          | a merged change and a labelled next issue        |
+| **Sponsor / partner / press**    | proof this is real and active      | live numbers, past events, a way to reach Waskar |
+| **Donor**                        | a reason and a route               | Open Collective                                  |
+
+## Voice
+
+Set by the homepage headline and consistent across surfaces: **"Come as you are. Leave with a flock."**
+
+Warm, plain, human, un-corporate. Stats are labelled _"people, not users"_, _"nights held"_, _"things shipped, so far"_ — the copy actively refuses SaaS metrics language. Preserve this. Do not introduce growth-deck vocabulary (engagement, users, platform, leverage) anywhere on the site.
+
+No emojis in UI copy.
+
+## Surfaces and their modes
+
+Mode is the design contract for a surface — what visitor success looks like there. See DESIGN.md for how mode governs decisions.
+
+| Surface   | Route                             | Mode                                                                            |
+| --------- | --------------------------------- | ------------------------------------------------------------------------------- |
+| Home      | `/`                               | **Persuade** — decide this is for you                                           |
+| Join      | `/join`                           | **Persuade** — convert to member                                                |
+| Support   | `/support`                        | **Persuade** — convert to donor                                                 |
+| About     | `/about`                          | **Read** — understand who we are                                                |
+| Events    | `/events`                         | **Operate** — find the next one, RSVP                                           |
+| Projects  | `/projects`, `/projects/[slug]`   | **Read** — browse and understand work                                           |
+| Resources | `/resources`, `/resources/[slug]` | **Operate** — locate a specific thing                                           |
+| Contact   | `/contact`                        | **Operate** — complete a form                                                   |
+| 404       | `/404`                            | **Operate** — recover                                                           |
+| Blog      | `/_blog/*`                        | **Read** — _currently unpublished; leading underscore excludes it from routing_ |
+
+## Product truth that constrains design
+
+These are real behaviors of the system. Designing against them produces work that cannot ship.
+
+- **Static build, no server.** Astro output is static on Vercel. There is no request-time personalization, no per-request nonce, no server session. Anything "live" is fetched at build time.
+- **Three homepage numbers have three different owners.** Member count is hand-maintained in `src/config.ts` (Luma's calendar-wide total is behind a paid tier). Nights held and things shipped are fetched at build from Luma's public ICS feed and GitHub by `src/lib/community.ts`. A design that displays these must tolerate all three being absent or stale.
+- **Luma is the RSVP system of record.** The site links out; it does not own registration.
+- **Content is file-based collections** — `blog`, `gallery`, `projects`, `resources`. Non-technical contributors add content by adding files. Any design that requires new content types requires a schema change and a contributor-docs update.
+- **The homepage photo section renders only when a real Builder Night photo exists** in the gallery collection, and is absent rather than filled with brand illustration. This is deliberate; do not add a placeholder.
+- **Interactivity is Alpine.js, self-hosted.** Mobile menu, contact form state, resources filter. There is no React.
+- **Contact form posts to Formspree.**
+
+## Constraints inherited from the repo
+
+- Accessibility is a stated commitment, not a nice-to-have — the site has a Code of Conduct, an `accessibility` issue label, and existing reduced-motion and reduced-transparency handling. Regressions here are defects, not polish.
+- CI runs lint, typecheck, and Playwright e2e including a CSP config. Design changes that break e2e selectors (`data-testid`) break the build.
+- Contributor docs in `docs/` are part of the product. A visual change that outdates `docs/design-system.md` is incomplete until that doc is updated.
+
+## Explicitly out of scope for design work
+
+- Blog surface (`src/pages/_blog/`) is intentionally off the air. Do not design it back on without a decision.
+- Newsletter: Beehiiv exists but is dormant; Substack is Waskar's personal blog, not the org's. The site should not imply an active newsletter.


### PR DESCRIPTION
# Description

`docs/design-system.md` records **what** our design values are — colors, fonts, button variants, hero assignments. It records nothing about **why**, or what has to stay true when someone changes them. That reasoning currently lives in CSS comments and in people's heads, which makes design review a matter of taste rather than a matter of contract.

These two files add the missing layer. They deliberately do **not** duplicate any token values; `DESIGN.md` opens by naming `docs/design-system.md` as authoritative and stating that if a value appears in both, `DESIGN.md` is the one that's wrong.

| File | Job |
| --- | --- |
| `docs/design-system.md` (existing, untouched) | *What the values are* — for someone making a change |
| `DESIGN.md` (new) | *Why they are what they are* — for someone deciding a change |
| `PRODUCT.md` (new) | Product truth that constrains design work |

## What's actually new here

Things that were true but written down nowhere:

- **The visual thesis.** Retro-warm and hand-made, resting on four interlocking decisions — and specifically that our offset shadows carry **zero blur** (`4px 4px 0`). That's the most identity-bearing token we have; a blurred shadow would break the look faster than a wrong color.
- **The motion contract**, promoted out of `global.css` comments. `.pcv-enter-*` vs `.pcv-loop-*` is an accessibility boundary, not a naming convention — including the `.pcv-loop-track` trap, where freezing it under `prefers-reduced-motion` without restoring `width: 100%` collapses the timeline spine to nothing.
- **A surface mode per route** (Persuade / Operate / Read / Experience), so page-level design calls stay consistent.
- **Product truth that invalidates bad designs early** — the static build, the three homepage numbers with three different owners, and why the Builder Night photo section is absent rather than filled with a placeholder.

## One verified finding

`.gradient-text` is defined at `src/styles/global.css:61` and referenced by **no template** — `grep -rn "gradient-text" src/ docs/` returns exactly that one line. `DESIGN.md` records the recommendation to delete it rather than carry it. Not done in this PR, since this one is docs-only.

## Type of Change

- [x] Documentation update

## Changes Made

- Add `PRODUCT.md` — product truth, audiences, voice, surface modes, constraints
- Add `DESIGN.md` — visual thesis, color rhythm, type scale, motion contract, known tensions

## How Has This Been Tested?

Not applicable — documentation only, no source or styling changes. Content was derived from the existing codebase (`tailwind.config.mjs`, `src/styles/global.css`, `src/config.ts`, `README.md`) rather than invented.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have read and followed the CONTRIBUTING.md guidelines