### PR TITLE
Support-page fix, dead CSS, and mechanical enforcement of the design contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Check CSP script hashes match the build
         run: npm run csp:hash
 
+      # Prose budgets and sentence case, measured on the built pages. Both rules
+      # drifted twice before a human caught them by reading; a source-level grep
+      # cannot see labels that components generate or data arrays supply.
+      - name: Check the design contract
+        run: npm run check:design
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepare": "husky",
     "data:refresh": "node scripts/refresh-community-data.mjs",
     "icons:generate": "node scripts/generate-icons.mjs",
-    "arcade:shots": "node scripts/capture-arcade-shots.mjs"
+    "arcade:shots": "node scripts/capture-arcade-shots.mjs",
+    "check:design": "node scripts/check-design-contract.mjs"
   },
   "lint-staged": {
     "*.astro": [

--- a/scripts/check-design-contract.mjs
+++ b/scripts/check-design-contract.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Mechanical enforcement for two rules in DESIGN.md that drifted twice each
+ * before anyone noticed, both times caught by a human reading carefully.
+ *
+ *   1. Prose budget by mode  (DESIGN.md, "The evidence contract", rule 2)
+ *   2. Sentence case on UI labels  (docs/writing-guide.md)
+ *
+ * Both are checked against the BUILT pages, not the source, for the reason
+ * DESIGN.md gives: components expand, and data-driven labels never appear as
+ * literals in any .astro file. A source-level grep missed nine labels on the
+ * first sweep and four more on the second — every one of them was generated
+ * or sat alone inside a multiline slot. The built HTML has no such hiding
+ * places.
+ *
+ * Run: npm run check:design   (requires `npm run build` first)
+ *
+ * This is a linter, not a judge. When it is wrong, fix the allowlist below and
+ * say why in the commit — do not silence the whole rule.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+
+/** Budgets from DESIGN.md's mode table. Page key -> [mode, limit]. */
+const BUDGETS = {
+  '': ['Persuade', 250], // home
+  about: ['Read', 550],
+  join: ['Persuade', 250],
+  support: ['Persuade', 250],
+  events: ['Operate', 200],
+  projects: ['Operate', 200],
+  resources: ['Operate', 200],
+  contact: ['Operate', 200],
+  arcade: ['Operate', 200],
+};
+
+/** DESIGN.md rule 2: a rung-1 object's interior is capped separately. */
+const OPERABLE_CAP = 120;
+
+/**
+ * Proper nouns that are legitimately capitalised mid-label.
+ *
+ * Anything here is a name someone else owns — a place, a product, a series, a
+ * person. Adding a phrase because it is "a heading we like capitalised" is
+ * exactly the drift this file exists to stop.
+ */
+const PROPER_NOUNS = [
+  'PhilaCon Valley',
+  'Open Collective',
+  'Pennovation Center',
+  'Pennovation Works',
+  'Pennovation',
+  'Braid Mill',
+  'Silicon Valley',
+  'Resilient Coders',
+  'Demo Day',
+  'Philadelphia',
+  'Philly',
+  'GitHub',
+  'Slack',
+  'Discord',
+  'Luma',
+  'Google Fonts',
+  'Code of Conduct',
+  'Shopping Debate',
+  'Community Handbook',
+  'Tap in NFC Lab',
+  'NFC',
+  'PATCH',
+  'Lab',
+  'Labs',
+  'Arcade',
+];
+
+/** Words that may be capitalised anywhere without making a label title case. */
+const ALWAYS_OK = new Set(['I', "I'm", "I'd", 'A', 'An', 'The']);
+
+const strip = (html) => html.replace(/<[^>]+>/g, ' ').replace(/&[a-z#0-9]+;/gi, ' ');
+const words = (text) => text.split(/\s+/).filter(Boolean).length;
+
+function mainOf(html) {
+  const m = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  return m ? m[1] : null;
+}
+
+/** Pulls out every subtree matching an opening tag that carries `attr`. */
+function extractMarked(html, attr) {
+  const found = [];
+  let rest = html;
+  const open = new RegExp(`<(\\w+)[^>]*\\b${attr}\\b[^>]*>`, 'i');
+  for (;;) {
+    const m = rest.match(open);
+    if (!m) break;
+    const tag = m[1];
+    const start = m.index;
+    // Walk nested same-name tags so we close on the right one.
+    const scan = new RegExp(`<${tag}\\b[^>]*>|</${tag}>`, 'gi');
+    scan.lastIndex = start;
+    let depth = 0;
+    let end = -1;
+    for (let t; (t = scan.exec(rest));) {
+      depth += t[0].startsWith('</') ? -1 : 1;
+      if (depth === 0) {
+        end = t.index + t[0].length;
+        break;
+      }
+    }
+    if (end === -1) break;
+    found.push(rest.slice(start, end));
+    rest = rest.slice(0, start) + ' ' + rest.slice(end);
+  }
+  return { without: rest, found };
+}
+
+function measure(html) {
+  const main = mainOf(html);
+  if (!main) return null;
+
+  // Rung-1 operable objects: counted separately, capped separately. Commands
+  // inside the object are subtracted too — rule 2 exempts `<pre>` wherever it
+  // sits, and an object made of terminal commands is the case it was written
+  // for. Without this the walkthrough reads 145 instead of its real 117.
+  const { without: noObjects, found: objects } = extractMarked(main, 'data-operable');
+  const objectWords = objects.reduce(
+    (n, o) => n + words(strip(o.replace(/<pre[\s\S]*?<\/pre>/gi, ' '))),
+    0,
+  );
+
+  // Commands are artifacts, not sentences.
+  const codeless = noObjects.replace(/<pre[\s\S]*?<\/pre>/gi, ' ');
+  const codeWords = words(strip(noObjects)) - words(strip(codeless));
+
+  const body = codeless.replace(/<script[\s\S]*?<\/script>/gi, ' ');
+  return { prose: words(strip(body)), objectWords, codeWords };
+}
+
+/** True when a label reads as Title Case rather than sentence case. */
+function isTitleCase(label) {
+  let text = label.trim();
+  if (!text || text.length > 90) return false;
+  for (const noun of PROPER_NOUNS) text = text.split(noun).join(' ');
+  const tokens = text.split(/[\s—–/·:,.!?()]+/).filter(Boolean);
+
+  let capsInARow = 0;
+  for (const [i, token] of tokens.entries()) {
+    const capitalised = /^[A-Z][a-z]+$/.test(token);
+    if (i === 0 || ALWAYS_OK.has(token) || !capitalised) {
+      capsInARow = capitalised && i > 0 && !ALWAYS_OK.has(token) ? 1 : 0;
+      continue;
+    }
+    capsInARow += 1;
+    if (capsInARow >= 2) return true;
+  }
+  return false;
+}
+
+function labelsIn(html) {
+  const main = mainOf(html) ?? html;
+  const out = [];
+  const patterns = [
+    /<h[1-3][^>]*>([\s\S]*?)<\/h[1-3]>/gi,
+    /<button[^>]*>([\s\S]*?)<\/button>/gi,
+    /<a[^>]*class="[^"]*\bbtn\b[^"]*"[^>]*>([\s\S]*?)<\/a>/gi,
+  ];
+  for (const re of patterns) {
+    for (let m; (m = re.exec(main));) {
+      const text = strip(m[1]).replace(/\s+/g, ' ').trim();
+      if (text) out.push(text);
+    }
+  }
+  return out;
+}
+
+const failures = [];
+const rows = [];
+
+for (const [page, [mode, limit]] of Object.entries(BUDGETS)) {
+  const file = page ? `dist/${page}/index.html` : 'dist/index.html';
+  if (!existsSync(file)) {
+    failures.push(`${file} is missing — run \`npm run build\` first.`);
+    continue;
+  }
+  const html = readFileSync(file, 'utf8');
+  const m = measure(html);
+  if (!m) {
+    failures.push(`${file} has no <main> landmark.`);
+    continue;
+  }
+
+  rows.push({ page: page || 'home', mode, limit, ...m });
+
+  if (m.prose > limit) {
+    failures.push(
+      `/${page} is ${m.prose} body words against a ${mode} budget of ${limit}. ` +
+        `Cut ${m.prose - limit}, or show the thing instead of describing it.`,
+    );
+  }
+  if (m.objectWords > OPERABLE_CAP) {
+    failures.push(
+      `/${page} has ${m.objectWords} words inside its operable object, over the ${OPERABLE_CAP} cap. ` +
+        `The object is proof, not an essay in disguise.`,
+    );
+  }
+
+  for (const label of labelsIn(html)) {
+    if (isTitleCase(label)) {
+      failures.push(
+        `/${page} label is Title Case: "${label}" — sentence case, per the writing guide.`,
+      );
+    }
+  }
+}
+
+const pad = (s, n) => String(s).padEnd(n);
+console.log(
+  `${pad('page', 12)}${pad('mode', 10)}${pad('prose', 8)}${pad('budget', 8)}object  code`,
+);
+for (const r of rows) {
+  console.log(
+    pad(r.page, 12) +
+      pad(r.mode, 10) +
+      pad(r.prose, 8) +
+      pad(r.limit, 8) +
+      pad(r.objectWords || '-', 8) +
+      (r.codeWords || '-'),
+  );
+}
+
+if (failures.length) {
+  console.error(`\n✗ ${failures.length} design-contract violation(s):\n`);
+  for (const f of failures) console.error(`  · ${f}`);
+  console.error('\nRules: DESIGN.md "The evidence contract" · docs/writing-guide.md\n');
+  process.exit(1);
+}
+
+console.log('\n✓ Prose budgets and sentence case hold.');

--- a/src/components/FirstPRWalkthrough.astro
+++ b/src/components/FirstPRWalkthrough.astro
@@ -62,7 +62,12 @@ const steps = [
 ];
 ---
 
-<fieldset class="pcv-pr" data-testid="first-pr-walkthrough">
+<!--
+  `data-operable` marks this as a rung-1 object for scripts/check-design-contract.mjs:
+  its interior is counted against the 120-word object cap, not the page's prose
+  budget, per DESIGN.md rule 2.
+-->
+<fieldset class="pcv-pr" data-testid="first-pr-walkthrough" data-operable>
   <legend class="sr-only">Your first pull request, step by step</legend>
 
   {

--- a/src/content/resources/example-resource.md
+++ b/src/content/resources/example-resource.md
@@ -1,5 +1,5 @@
 ---
-title: 'Getting Started with Open Source'
+title: 'Getting started with open source'
 description: 'A beginner-friendly guide to making your first open source contribution.'
 category: 'Tutorial'
 level: 'Beginner'

--- a/src/content/resources/first-pull-request.md
+++ b/src/content/resources/first-pull-request.md
@@ -1,5 +1,5 @@
 ---
-title: 'How to Make Your First Pull Request'
+title: 'How to make your first pull request'
 description: 'A beginner-friendly, step-by-step walkthrough of forking, cloning, branching, committing, and opening your first pull request on this repo.'
 category: 'Tutorial'
 level: 'Beginner'

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -27,8 +27,7 @@ import { site, links } from '../config';
         <div>
           <h2 class="text-3xl font-bold mb-6">Let's connect</h2>
           <p class="text-lg text-brand-dark/70 mb-8">
-            Whether you have a question about our events, want to contribute, or just want to
-            connect with the community – we're here for you.
+            A question, an offer, or just saying hello — all of it reaches a person.
           </p>
 
           <!-- Contact Methods -->

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -197,9 +197,7 @@ const photos = (await getCollection('gallery')).sort(
   <section class="section-padding bg-accent-400 text-white border-t-[3px]">
     <div class="container-custom text-center">
       <h2 class="text-4xl font-bold mb-6">Ready to join us?</h2>
-      <p class="text-xl mb-8 max-w-2xl mx-auto opacity-90">
-        RSVP for our next event and become part of Philadelphia's thriving tech community.
-      </p>
+      <p class="text-xl mb-8 max-w-2xl mx-auto opacity-90">Show up before you feel ready.</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <Button href={links.luma} external variant="secondary" size="lg">
           View events on Luma

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -2,226 +2,147 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Button from '../components/Button.astro';
 import { links } from '../config';
+
+/**
+ * Mode: Persuade. Budget: 250 body words (DESIGN.md).
+ *
+ * Was 320 words carried by four stock-icon cards — a building, a book, a
+ * globe, a group of people — the treatment the evidence contract bans. An
+ * icon of a building does not tell anyone the room costs money; the sentence
+ * does. So the cards became four lines that name real costs.
+ *
+ * The removed tax-deductibility claim is the important change here. See the
+ * comment on the Open Collective block below.
+ */
+
+const costs = [
+  { name: 'The room', line: 'Pennovation and the Braid Mill are rented, not lent.' },
+  {
+    name: 'The hardware',
+    line: 'NFC tags, boards, components — whatever people take home working.',
+  },
+  { name: 'This site', line: 'Domain, hosting, and the tools the community builds on.' },
+  { name: 'The invite', line: 'Reaching people who have never heard of us and should have.' },
+];
+
+const otherWays = [
+  {
+    name: 'Sponsor an event',
+    line: 'Cover a room and its materials, and meet the people in it.',
+    href: '/contact',
+    cta: 'Talk to us',
+  },
+  {
+    name: 'Mentor',
+    line: 'Sit at a table for an evening. That is the whole job.',
+    href: '/join',
+    cta: 'Get involved',
+  },
+  {
+    name: 'Offer space',
+    line: 'A room that holds thirty people is the single hardest thing to find.',
+    href: '/contact',
+    cta: 'Offer a space',
+  },
+  {
+    name: 'Share a job',
+    line: 'Hiring somewhere worth working? Our community should hear about it.',
+    href: '/contact',
+    cta: 'Send it over',
+  },
+];
 ---
 
 <BaseLayout
   title="Support PhilaCon Valley - Donate"
-  description="Support PhilaCon Valley's mission to make Philadelphia a tech hub by us, for us. Your donation keeps events free and accessible."
+  description="Free events cost money. See exactly where it goes, and chip in on Open Collective."
 >
-  <!-- Hero Section -->
   <section class="bg-brand-purple text-white py-20">
     <div class="container-custom">
       <div class="max-w-4xl mx-auto text-center">
         <h1 class="text-5xl md:text-6xl font-bold mb-6">Support our mission</h1>
-        <p class="text-2xl text-white/85">
-          Help keep PhilaCon Valley free and accessible for everyone
-        </p>
+        <p class="text-2xl text-white/85">Free events still cost money.</p>
       </div>
     </div>
   </section>
 
-  <!-- Why Support -->
   <section class="section-padding">
     <div class="container-custom">
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-4xl font-bold mb-8 text-center">Why your support matters</h2>
-        <p class="text-xl text-brand-dark/70 leading-relaxed mb-8 text-center">
-          PhilaCon Valley is committed to keeping all events free and accessible. We believe
-          financial barriers shouldn't prevent anyone from learning tech skills and building their
-          career. Your support makes this possible.
-        </p>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-8 mt-12">
-          <div class="bg-white p-6 rounded-retro border-2 border-brand-dark/10 shadow-retro">
-            <h3 class="text-2xl font-bold mb-3 flex items-center">
-              <svg
-                class="w-6 h-6 text-primary-600 mr-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                ></path>
-              </svg>
-              Event venues
-            </h3>
-            <p class="text-brand-dark/60">
-              Rent spaces like Pennovation Works that provide the infrastructure for hands-on
-              collaboration and workshops.
-            </p>
-          </div>
-
-          <div class="bg-white p-6 rounded-retro border-2 border-brand-dark/10 shadow-retro">
-            <h3 class="text-2xl font-bold mb-3 flex items-center">
-              <svg
-                class="w-6 h-6 text-primary-600 mr-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                ></path>
-              </svg>
-              Learning resources
-            </h3>
-            <p class="text-brand-dark/60">
-              Create and share free tutorials, workshops materials, and educational content for the
-              community.
-            </p>
-          </div>
-
-          <div class="bg-white p-6 rounded-retro border-2 border-brand-dark/10 shadow-retro">
-            <h3 class="text-2xl font-bold mb-3 flex items-center">
-              <svg
-                class="w-6 h-6 text-primary-600 mr-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-                ></path>
-              </svg>
-              Infrastructure
-            </h3>
-            <p class="text-brand-dark/60">
-              Maintain website, tools, and platforms that help the community connect, collaborate,
-              and grow.
-            </p>
-          </div>
-
-          <div class="bg-white p-6 rounded-retro border-2 border-brand-dark/10 shadow-retro">
-            <h3 class="text-2xl font-bold mb-3 flex items-center">
-              <svg
-                class="w-6 h-6 text-primary-600 mr-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                ></path>
-              </svg>
-              Community growth
-            </h3>
-            <p class="text-brand-dark/60">
-              Support outreach efforts to connect with more underrepresented folks in tech across
-              Philadelphia.
-            </p>
-          </div>
-        </div>
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-4xl font-bold mb-10">Where it goes</h2>
+        <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-8 m-0">
+          {
+            costs.map((cost) => (
+              <div>
+                <dt class="font-display text-2xl font-bold mb-1">{cost.name}</dt>
+                <dd class="m-0 text-brand-dark/70">{cost.line}</dd>
+              </div>
+            ))
+          }
+        </dl>
       </div>
     </div>
   </section>
 
-  <!-- Open Collective Section -->
+  <!--
+    No tax-deductibility claim here, deliberately.
+
+    This block used to read "Tax-deductible receipts available". That was not
+    true. PhilaCon Valley, Inc. has not filed its Articles, so it holds no
+    501(c)(3) determination; and Open Collective Foundation — evaluated and not
+    pursued — is a 501(c)(6), under which donations are explicitly not
+    deductible either. Telling a donor otherwise is a claim about their tax
+    return, so it does not go back on the page until a determination letter
+    exists to point at.
+  -->
   <section class="section-padding bg-brand-yellow border-t-[3px]">
     <div class="container-custom">
-      <div class="max-w-4xl mx-auto text-center">
-        <h2 class="text-4xl font-bold mb-8">Support via Open Collective</h2>
+      <div class="max-w-3xl mx-auto text-center">
+        <h2 class="text-4xl font-bold mb-6">Read the ledger first</h2>
         <p class="text-lg text-brand-dark/70 mb-8">
-          We use Open Collective for transparent, community-driven financial management. You can see
-          exactly how every dollar is spent and the impact it makes.
+          Every dollar in and out is public on Open Collective. Look at what we spent last month
+          before you decide we are worth funding.
         </p>
-
-        <!-- Open Collective Embed -->
-        <div class="bg-white rounded-retro border-2 border-brand-dark/10 shadow-retro-lg p-8 mb-8">
-          <div class="mb-6">
-            <h3 class="text-2xl font-bold mb-4">Make a contribution</h3>
-            <p class="text-brand-dark/60 mb-6">
-              One-time or recurring donations – every amount helps keep our events free and
-              accessible.
-            </p>
-          </div>
-
-          <!-- Open Collective Widget Placeholder -->
-          <div class="bg-primary-100 rounded-retro border-2 border-brand-dark/10 p-12 mb-6">
-            <p class="text-lg font-semibold mb-4">Support us on Open Collective</p>
-            <p class="text-brand-dark/60 mb-6">
-              Visit our Open Collective page to make a one-time or recurring contribution. All
-              transactions are transparent and publicly visible.
-            </p>
-            <Button href={links.openCollective} external variant="primary" size="lg">
-              Donate on Open Collective
-            </Button>
-          </div>
-
-          <div class="text-sm text-brand-dark/50">
-            <p class="mb-2">✓ Fully transparent – see how funds are used</p>
-            <p class="mb-2">✓ Secure payment processing</p>
-            <p>✓ Tax-deductible receipts available</p>
-          </div>
-        </div>
+        <Button href={links.openCollective} external variant="primary" size="lg">
+          Chip in on Open Collective
+        </Button>
+        <p class="text-sm text-brand-dark/50 mt-6 m-0">
+          One-time or recurring. We are not yet a registered charity, so donations are not
+          tax-deductible.
+        </p>
       </div>
     </div>
   </section>
 
-  <!-- Other ways to support -->
   <section class="section-padding">
     <div class="container-custom">
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-3xl font-bold mb-8 text-center">Other ways to support</h2>
-        <div class="space-y-6">
-          <div class="bg-white rounded-retro border-2 border-brand-dark/10 shadow-retro p-6">
-            <h3 class="text-xl font-bold mb-2">Sponsor an event</h3>
-            <p class="text-brand-dark/60 mb-4">
-              Companies and organizations can sponsor specific events. Your support covers venue
-              costs, refreshments, and materials while gaining visibility with our community.
-            </p>
-            <Button href="/contact" variant="outline"> Inquire about sponsorship </Button>
-          </div>
-
-          <div class="bg-white rounded-retro border-2 border-brand-dark/10 shadow-retro p-6">
-            <h3 class="text-xl font-bold mb-2">Volunteer as a mentor</h3>
-            <p class="text-brand-dark/60 mb-4">
-              Share your expertise by mentoring community members, leading workshops, or supporting
-              Lab sessions.
-            </p>
-            <Button href="/join" variant="outline"> Get involved </Button>
-          </div>
-
-          <div class="bg-white rounded-retro border-2 border-brand-dark/10 shadow-retro p-6">
-            <h3 class="text-xl font-bold mb-2">Provide venue space</h3>
-            <p class="text-brand-dark/60 mb-4">
-              Do you have space we could use for events? Help us bring tech education to more people
-              across Philadelphia.
-            </p>
-            <Button href="/contact" variant="outline"> Offer venue space </Button>
-          </div>
-
-          <div class="bg-white rounded-retro border-2 border-brand-dark/10 shadow-retro p-6">
-            <h3 class="text-xl font-bold mb-2">Share job opportunities</h3>
-            <p class="text-brand-dark/60 mb-4">
-              Hiring? Share inclusive job opportunities with our community. We especially welcome
-              roles from companies committed to diversity and equity.
-            </p>
-            <Button href="/contact" variant="outline"> Post a job </Button>
-          </div>
-        </div>
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold mb-10">If money is not the thing</h2>
+        <ul class="space-y-8 list-none p-0 m-0">
+          {
+            otherWays.map((way) => (
+              <li>
+                <h3 class="text-2xl font-bold mb-1">{way.name}</h3>
+                <p class="text-brand-dark/70 m-0">{way.line}</p>
+                <a
+                  href={way.href}
+                  class="inline-block font-display font-bold mt-2 text-brand-dark no-underline border-b-2 border-brand-pink hover:text-accent-700"
+                >
+                  {way.cta} →
+                </a>
+              </li>
+            ))
+          }
+        </ul>
       </div>
     </div>
   </section>
 
-  <!-- CTA -->
   <section class="section-padding bg-accent-400 text-white border-t-[3px]">
     <div class="container-custom text-center">
-      <h2 class="text-4xl font-bold mb-6">Ready to make an impact?</h2>
+      <h2 class="text-4xl font-bold mb-6">Keep it free</h2>
       <p class="text-xl mb-8 max-w-2xl mx-auto opacity-90">
-        Your support helps us build the Philadelphia tech community we want to see.
+        A pigeon flies alone. A flock goes much further.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <Button href={links.openCollective} external variant="secondary" size="lg">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,11 +57,6 @@
     @apply py-12 md:py-16 lg:py-24;
   }
 
-  /* Gradient text effect */
-  .gradient-text {
-    @apply bg-gradient-to-r from-accent-400 to-accent-600 bg-clip-text text-transparent;
-  }
-
   /* Card styles — retro offset shadow.
      Transition names its two properties: `all` would animate anything that
      happens to differ on hover, off the GPU. The hover lift is gated to


### PR DESCRIPTION
Stacked on #131 — **base is `waskar/design-voice-and-density`, not `main`.** Both files this touches most (`support.astro`, `global.css`) are heavily changed by #131, so branching from `main` would have guaranteed a conflict. Merge #131 first; this retargets to `main` automatically.

## 1. The support page was making a false claim to donors

It said **"Tax-deductible receipts available."** It is not.

- PhilaCon Valley, Inc. has not filed its Articles → no 501(c)(3) determination.
- Open Collective Foundation was evaluated and **deliberately not pursued** because it is a 501(c)(6), under which donations are explicitly not deductible (`memory/context/org-context.md:116`).

Both routes to that claim are closed. This is a statement about someone else's tax return, so the page now says the opposite, plainly, at the point of decision. It goes back only when there's a determination letter to point at.

**This is the one thing in this PR I'd merge on its own.**

## 2. Density and dead code

- Support: **320 → 201 words** against a 250 budget. Four stock-icon cards became four lines naming real costs — an icon of a building doesn't tell anyone the room is rented.
- Removed `.gradient-text` from `global.css`. Defined once, referenced nowhere.

## 3. `npm run check:design`

Both rules have drifted twice, and both times a human caught it by reading carefully. That's luck, not a control.

The checker measures **built** pages, implementing DESIGN.md rule 2 literally: everything in `<main>`, minus `<pre>`/`<code>`, minus the interior of anything marked `data-operable` (capped separately at 120). The walkthrough measures **117** under it — matching the hand count that set the cap.

```
page        mode      prose   budget  object  code
home        Persuade  181     250     -       -
about       Read      326     550     -       -
join        Persuade  154     250     117     -
support     Persuade  201     250     -       -
events      Operate   196     200     -       -
contact     Operate   199     200     -       -
```

**Verified in both directions:** injected Title Case heading → exit 1; clean build → exit 0. A checker only ever tested green isn't a checker.

Wired into CI after the build, beside the CSP hash check.

### It found four real violations on the way in

- `/events` 203 and `/contact` 208 against Operate's 200 — both CTA paragraphs restated what the button below already said.
- Two resource titles Title Case in **content frontmatter** — invisible to every earlier sweep because they're data, not markup. This is exactly the class of miss that motivated the checker.

## Verification

- `npm run lint` — clean
- `npm run build` — clean
- `npx playwright test` — 38 passed, 9 skipped, 0 failed
- `npm run check:design` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooUB7oD1Ed5d3r5Qka12m