### PR TITLE
Ship the mono font and build the agency surface

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,7 @@ const {
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700;800;900&family=Nunito:ital,wght@0,400;0,600;0,700;0,800;1,600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;600;700;800;900&family=JetBrains+Mono:wght@400;500&family=Nunito:ital,wght@0,400;0,600;0,700;0,800;1,600&display=swap"
     />
 
     <SEO title={title} description={description} image={image} type={type} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,66 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ---------------------------------------------------------------------------
+   Brand Book §09 — the agency surface.
+
+   One brand, two dials. The community surface is the default: cream, loud,
+   mascot-forward, 2px ink stroke, hard offset shadows. The agency surface keeps
+   every shape and drops the volume for nonprofits and community orgs.
+
+   Wrap a page or a section in [data-surface="agency"] to switch. Shapes do not
+   change — pills stay pills, 20px radii stay 20px. Only the volume moves.
+   --------------------------------------------------------------------------- */
+[data-surface='agency'] {
+  /* Page background: off-cream, calmer than the community cream. */
+  --surface-bg: #fff9f0;
+  /* Ink stroke: still present, less assertive. */
+  --surface-stroke: 1.5px;
+  /* Shadows: soft offset only. The loud ink-stamp variant is community-only. */
+  --surface-shadow: 4px 4px 0 rgba(26, 26, 26, 0.08);
+  --surface-shadow-lg: 6px 6px 0 rgba(26, 26, 26, 0.08);
+
+  background-color: var(--surface-bg);
+}
+
+/* Type steps down. Baloo 2 sits at 700 rather than 800, and Nunito does more
+   of the work. Display sizes do not go large on this surface. */
+[data-surface='agency'] h1,
+[data-surface='agency'] h2,
+[data-surface='agency'] h3,
+[data-surface='agency'] h4 {
+  @apply font-semibold;
+}
+
+[data-surface='agency'] h1 {
+  @apply text-3xl md:text-4xl lg:text-5xl;
+}
+
+[data-surface='agency'] h2 {
+  @apply text-2xl md:text-3xl;
+}
+
+/* Borders drop from 2px to 1.5px across cards, inputs, and buttons. */
+[data-surface='agency'] .border-2 {
+  border-width: var(--surface-stroke);
+}
+
+/* Shadows soften. No ink-stamp on this surface. */
+[data-surface='agency'] .shadow-retro {
+  box-shadow: var(--surface-shadow);
+}
+
+[data-surface='agency'] .shadow-retro-lg {
+  box-shadow: var(--surface-shadow-lg);
+}
+
+/* NOTE: the Book §05 names three shadows — retro, retro-lg, retro-ink. The live
+   config ships retro, retro-lg, retro-hover. There is no retro-ink utility to
+   soften here. See Addendum 01 Part 4. */
+[data-surface='agency'] .shadow-retro-hover {
+  box-shadow: var(--surface-shadow-lg);
+}
+
 @layer base {
   html {
     @apply scroll-smooth;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -51,6 +51,11 @@ export default {
       fontFamily: {
         sans: ['"Nunito"', 'system-ui', 'sans-serif'],
         display: ['"Baloo 2"', 'cursive', 'system-ui', 'sans-serif'],
+        // Brand Book §04 — the sanctioned companion. Code samples, metadata
+        // rows, captions, and the small technical labels. §11 specifies it for
+        // the IG handle, flyer event meta, carousel pagination, deck footer
+        // meta, and badge pronouns.
+        mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       boxShadow: {
         retro: '4px 4px 0 rgba(26,26,26,0.15)',


### PR DESCRIPTION
Two things the Brand Book documents that the site never had. Both found while auditing Edition 1.0 against the live code.

## §04 — JetBrains Mono

§04 names JetBrains Mono as the sanctioned companion and notes the repo does not ship one. Three months later it still did not.

This is not cosmetic. §11 specifies mono for the Instagram handle, the flyer event meta, the carousel pagination, the deck footer meta, and the badge pronouns — **five of the six application templates could not be built as written.**

Added to the Google Fonts link in `BaseLayout.astro` and as a `mono` family in `tailwind.config.mjs`.

## §09 — the agency surface

§09 specifies an agency surface as a token override on `[data-surface="agency"]`. The string appeared nowhere in the repo, so the arm with a paying client had no visual surface at all.

Built to spec in `global.css`: off-cream ground, 1.5px stroke, softened shadows, type stepped down. Shapes do not change — pills stay pills and radii stay 20px. Same neighborhood, indoor voice.

## One drift found while building it

§05 names three system shadows: `retro`, `retro-lg`, `retro-ink`. The config ships `retro`, `retro-lg`, `retro-hover`. There is no `retro-ink`, so §06's button recipe — "pill radius, 2px ink border, RETRO-INK shadow" — cannot be built as written. §05 also says hover stretches to `6 6 0` while the config uses `8 8 0`.

Left a note at the call site rather than inventing the token in this PR. Tracked in `PhilaCon_Valley_Brand_Book_Addendum-01_2026-08-11.md`, Part 4.

## Verification

`npm run build` passes, 16 pages, before and after lint-staged reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)